### PR TITLE
Fix Jekyll configuration causing site-wide 404 errors

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -35,15 +35,12 @@ exclude:
   - package-lock.json
   - src/
 
+# Permalink configuration
+permalink: pretty
+
 # Collections and defaults
 defaults:
   - scope:
       path: ""
-      type: "pages"
     values:
       layout: "book"
-
-# Ensure Jekyll processes the site correctly
-safe: true
-source: .
-destination: ./_site

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@ title: "Supabaseアーキテクチャパターン実践技術書"
 description: "スケーラブルな3層構成の設計と実装 - 初心者から上級者まで段階的に学べる、Supabase完全マスターガイド"
 author: "ITDO Inc.（株式会社アイティードゥ）"
 version: "1.0.0"
+permalink: /
 ---
 # Supabaseアーキテクチャパターン実践技術書
 


### PR DESCRIPTION
## 🔧 Issue

The entire site was returning 404 errors despite successful GitHub Pages builds. This was caused by problematic Jekyll configuration settings.

## ✅ Root Cause Analysis

The issue was in `_config.yml`:
1. **`safe: true`** - This restrictive setting can prevent proper Jekyll processing on GitHub Pages
2. **Explicit `source`/`destination`** - These can conflict with GitHub Pages' build process
3. **Type specification in defaults** - Can cause page processing issues

## 🚀 Solution

### Configuration Cleanup
- ❌ Removed `safe: true` (restrictive for GitHub Pages)
- ❌ Removed explicit `source: .` and `destination: ./_site`
- ❌ Removed `type: "pages"` from defaults scope
- ✅ Added `permalink: pretty` for clean URLs
- ✅ Added explicit `permalink: /` to index.md

### Before vs After

**Before (_config.yml)**:
```yaml
defaults:
  - scope:
      path: ""
      type: "pages"     # ← This was problematic
    values:
      layout: "book"

safe: true              # ← This was too restrictive
source: .
destination: ./_site
```

**After (_config.yml)**:
```yaml
permalink: pretty       # ← Clean URLs
defaults:
  - scope:
      path: ""          # ← Simplified scope
    values:
      layout: "book"
```

## 🧪 Expected Result

- ✅ Main site should load at https://itdojp.github.io/supabase-architecture-patterns-book/
- ✅ All internal pages should be accessible
- ✅ Navigation links should work properly
- ✅ Clean URLs (no .html extensions needed)

## 📋 Technical Details

This is a common GitHub Pages + Jekyll issue where overly restrictive or conflicting configuration prevents the static site generator from properly processing markdown files into HTML.

🤖 Generated with [Claude Code](https://claude.ai/code)