### PR TITLE
Add visual diagrams for Supabase architecture patterns

### DIFF
--- a/docs/assets/images/diagrams/architecture-comparison.svg
+++ b/docs/assets/images/diagrams/architecture-comparison.svg
@@ -1,0 +1,172 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="800" height="600" viewBox="0 0 800 600" xmlns="http://www.w3.org/2000/svg">
+  <title>Supabaseアーキテクチャパターン比較</title>
+  <desc>クライアントサイド、Edge Functions、APIサーバーの比較と適用シナリオ</desc>
+  <defs>
+    <style>
+      :root {
+        --svg-bg: #ffffff;
+        --svg-text: #1a1a1a;
+        --svg-primary: #0066cc;
+        --svg-success: #16a34a;
+        --svg-warning: #ca8a04;
+        --svg-error: #dc2626;
+        --svg-neutral: #6b7280;
+      }
+      .title-text { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 16px; font-weight: 600; fill: var(--svg-text); }
+      .pattern-title { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 12px; font-weight: 500; fill: var(--svg-bg); }
+      .metric-text { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 12px; font-weight: 400; fill: var(--svg-text); }
+      .annotation-text { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 10px; font-weight: 400; fill: var(--svg-neutral); }
+      .client-pattern { fill: var(--svg-primary); stroke: var(--svg-primary); stroke-width: 2; }
+      .edge-pattern { fill: var(--svg-warning); stroke: var(--svg-warning); stroke-width: 2; }
+      .server-pattern { fill: var(--svg-success); stroke: var(--svg-success); stroke-width: 2; }
+      .score-high { fill: var(--svg-success); fill-opacity: 0.3; }
+      .score-medium { fill: var(--svg-warning); fill-opacity: 0.3; }
+      .score-low { fill: var(--svg-error); fill-opacity: 0.3; }
+    </style>
+  </defs>
+
+  <!-- Title -->
+  <text x="400" y="30" class="title-text" text-anchor="middle">Supabaseアーキテクチャパターン比較</text>
+
+  <!-- Client-Side Pattern -->
+  <g id="client-side-pattern">
+    <rect x="60" y="60" width="220" height="200" class="client-pattern" rx="4"/>
+    <text x="170" y="80" class="pattern-title" text-anchor="middle">クライアントサイド直接接続</text>
+    
+    <!-- Architecture Diagram -->
+    <rect x="80" y="90" width="180" height="80" fill="var(--svg-bg)" stroke="var(--svg-primary)" stroke-width="1" rx="4"/>
+    <text x="170" y="110" class="metric-text" text-anchor="middle" font-weight="500">アーキテクチャ</text>
+    <text x="90" y="125" class="annotation-text">Browser/Mobile App</text>
+    <text x="130" y="140" class="annotation-text">↓ 直接接続</text>
+    <text x="90" y="155" class="annotation-text">Supabase Database</text>
+    <text x="90" y="165" class="annotation-text">(RLS有効)</text>
+    
+    <!-- Characteristics -->
+    <rect x="80" y="180" width="180" height="70" fill="var(--svg-bg)" stroke="var(--svg-primary)" stroke-width="1" rx="4"/>
+    <text x="170" y="195" class="metric-text" text-anchor="middle" font-weight="500">特徴</text>
+    <text x="90" y="210" class="annotation-text">✓ 実装が簡単</text>
+    <text x="90" y="225" class="annotation-text">✓ リアルタイム対応</text>
+    <text x="90" y="240" class="annotation-text">✗ ビジネスロジック制限</text>
+  </g>
+
+  <!-- Edge Functions Pattern -->
+  <g id="edge-functions-pattern">
+    <rect x="290" y="60" width="220" height="200" class="edge-pattern" rx="4"/>
+    <text x="400" y="80" class="pattern-title" text-anchor="middle">Edge Functions パターン</text>
+    
+    <!-- Architecture Diagram -->
+    <rect x="310" y="90" width="180" height="80" fill="var(--svg-bg)" stroke="var(--svg-warning)" stroke-width="1" rx="4"/>
+    <text x="400" y="110" class="metric-text" text-anchor="middle" font-weight="500">アーキテクチャ</text>
+    <text x="320" y="125" class="annotation-text">Browser/Mobile App</text>
+    <text x="360" y="140" class="annotation-text">↓ API呼出</text>
+    <text x="320" y="155" class="annotation-text">Edge Functions (Deno)</text>
+    <text x="320" y="165" class="annotation-text">→ Supabase DB</text>
+    
+    <!-- Characteristics -->
+    <rect x="310" y="180" width="180" height="70" fill="var(--svg-bg)" stroke="var(--svg-warning)" stroke-width="1" rx="4"/>
+    <text x="400" y="195" class="metric-text" text-anchor="middle" font-weight="500">特徴</text>
+    <text x="320" y="210" class="annotation-text">✓ サーバーレス</text>
+    <text x="320" y="225" class="annotation-text">✓ 低レイテンシ</text>
+    <text x="320" y="240" class="annotation-text">✓ カスタムロジック</text>
+  </g>
+
+  <!-- API Server Pattern -->
+  <g id="api-server-pattern">
+    <rect x="520" y="60" width="220" height="200" class="server-pattern" rx="4"/>
+    <text x="630" y="80" class="pattern-title" text-anchor="middle">APIサーバー パターン</text>
+    
+    <!-- Architecture Diagram -->
+    <rect x="540" y="90" width="180" height="80" fill="var(--svg-bg)" stroke="var(--svg-success)" stroke-width="1" rx="4"/>
+    <text x="630" y="110" class="metric-text" text-anchor="middle" font-weight="500">アーキテクチャ</text>
+    <text x="550" y="125" class="annotation-text">Browser/Mobile App</text>
+    <text x="590" y="140" class="annotation-text">↓ REST/GraphQL</text>
+    <text x="550" y="155" class="annotation-text">Backend Server</text>
+    <text x="550" y="165" class="annotation-text">→ Supabase Client</text>
+    
+    <!-- Characteristics -->
+    <rect x="540" y="180" width="180" height="70" fill="var(--svg-bg)" stroke="var(--svg-success)" stroke-width="1" rx="4"/>
+    <text x="630" y="195" class="metric-text" text-anchor="middle" font-weight="500">特徴</text>
+    <text x="550" y="210" class="annotation-text">✓ 完全な制御</text>
+    <text x="550" y="225" class="annotation-text">✓ 複雑なロジック対応</text>
+    <text x="550" y="240" class="annotation-text">✗ インフラ管理必要</text>
+  </g>
+
+  <!-- Performance Comparison -->
+  <g id="performance-comparison">
+    <rect x="60" y="280" width="680" height="140" fill="var(--svg-neutral)" fill-opacity="0.05" stroke="var(--svg-text)" stroke-width="2" rx="4"/>
+    <text x="400" y="300" class="metric-text" text-anchor="middle" font-weight="500">パフォーマンス比較</text>
+    
+    <!-- Metrics Table Headers -->
+    <text x="120" y="320" class="metric-text" font-weight="500">評価項目</text>
+    <text x="300" y="320" class="metric-text" text-anchor="middle">クライアント</text>
+    <text x="450" y="320" class="metric-text" text-anchor="middle">Edge Functions</text>
+    <text x="600" y="320" class="metric-text" text-anchor="middle">APIサーバー</text>
+    
+    <!-- Latency -->
+    <text x="120" y="340" class="annotation-text">レイテンシ</text>
+    <rect x="260" y="330" width="80" height="15" class="score-high" rx="2"/>
+    <text x="300" y="341" class="annotation-text" text-anchor="middle">低 (直接)</text>
+    <rect x="410" y="330" width="80" height="15" class="score-high" rx="2"/>
+    <text x="450" y="341" class="annotation-text" text-anchor="middle">低 (Edge)</text>
+    <rect x="560" y="330" width="80" height="15" class="score-medium" rx="2"/>
+    <text x="600" y="341" class="annotation-text" text-anchor="middle">中</text>
+    
+    <!-- Scalability -->
+    <text x="120" y="360" class="annotation-text">スケーラビリティ</text>
+    <rect x="260" y="350" width="80" height="15" class="score-medium" rx="2"/>
+    <text x="300" y="361" class="annotation-text" text-anchor="middle">中</text>
+    <rect x="410" y="350" width="80" height="15" class="score-high" rx="2"/>
+    <text x="450" y="361" class="annotation-text" text-anchor="middle">高 (自動)</text>
+    <rect x="560" y="350" width="80" height="15" class="score-high" rx="2"/>
+    <text x="600" y="361" class="annotation-text" text-anchor="middle">高</text>
+    
+    <!-- Security -->
+    <text x="120" y="380" class="annotation-text">セキュリティ</text>
+    <rect x="260" y="370" width="80" height="15" class="score-medium" rx="2"/>
+    <text x="300" y="381" class="annotation-text" text-anchor="middle">中 (RLS依存)</text>
+    <rect x="410" y="370" width="80" height="15" class="score-high" rx="2"/>
+    <text x="450" y="381" class="annotation-text" text-anchor="middle">高</text>
+    <rect x="560" y="370" width="80" height="15" class="score-high" rx="2"/>
+    <text x="600" y="381" class="annotation-text" text-anchor="middle">高</text>
+    
+    <!-- Complexity -->
+    <text x="120" y="400" class="annotation-text">実装複雑度</text>
+    <rect x="260" y="390" width="80" height="15" class="score-high" rx="2"/>
+    <text x="300" y="401" class="annotation-text" text-anchor="middle">低</text>
+    <rect x="410" y="390" width="80" height="15" class="score-medium" rx="2"/>
+    <text x="450" y="401" class="annotation-text" text-anchor="middle">中</text>
+    <rect x="560" y="390" width="80" height="15" class="score-low" rx="2"/>
+    <text x="600" y="401" class="annotation-text" text-anchor="middle">高</text>
+  </g>
+
+  <!-- Use Case Recommendations -->
+  <g id="use-cases">
+    <rect x="60" y="440" width="680" height="140" fill="var(--svg-primary)" fill-opacity="0.05" stroke="var(--svg-primary)" stroke-width="2" rx="4"/>
+    <text x="400" y="460" class="metric-text" text-anchor="middle" font-weight="500">推奨ユースケース</text>
+    
+    <!-- Client-Side Use Cases -->
+    <rect x="80" y="470" width="200" height="90" fill="var(--svg-bg)" stroke="var(--svg-primary)" stroke-width="1" rx="4"/>
+    <text x="180" y="490" class="metric-text" text-anchor="middle" font-weight="500">クライアントサイド</text>
+    <text x="90" y="505" class="annotation-text">• MVP/プロトタイプ</text>
+    <text x="90" y="520" class="annotation-text">• リアルタイムチャット</text>
+    <text x="90" y="535" class="annotation-text">• シンプルなCRUD</text>
+    <text x="90" y="550" class="annotation-text">• 個人プロジェクト</text>
+    
+    <!-- Edge Functions Use Cases -->
+    <rect x="300" y="470" width="200" height="90" fill="var(--svg-bg)" stroke="var(--svg-warning)" stroke-width="1" rx="4"/>
+    <text x="400" y="490" class="metric-text" text-anchor="middle" font-weight="500">Edge Functions</text>
+    <text x="310" y="505" class="annotation-text">• Webhook処理</text>
+    <text x="310" y="520" class="annotation-text">• 外部API統合</text>
+    <text x="310" y="535" class="annotation-text">• 軽量なビジネスロジック</text>
+    <text x="310" y="550" class="annotation-text">• イメージ処理</text>
+    
+    <!-- API Server Use Cases -->
+    <rect x="520" y="470" width="200" height="90" fill="var(--svg-bg)" stroke="var(--svg-success)" stroke-width="1" rx="4"/>
+    <text x="620" y="490" class="metric-text" text-anchor="middle" font-weight="500">APIサーバー</text>
+    <text x="530" y="505" class="annotation-text">• エンタープライズアプリ</text>
+    <text x="530" y="520" class="annotation-text">• 複雑なビジネスロジック</text>
+    <text x="530" y="535" class="annotation-text">• マイクロサービス</text>
+    <text x="530" y="550" class="annotation-text">• レガシーシステム統合</text>
+  </g>
+</svg>

--- a/docs/assets/images/diagrams/auth-flow-rls.svg
+++ b/docs/assets/images/diagrams/auth-flow-rls.svg
@@ -1,0 +1,168 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="800" height="600" viewBox="0 0 800 600" xmlns="http://www.w3.org/2000/svg">
+  <title>Supabase認証フローとRow Level Security</title>
+  <desc>ユーザー認証、JWTトークン生成、RLSポリシー適用の完全なフロー図</desc>
+  <defs>
+    <style>
+      :root {
+        --svg-bg: #ffffff;
+        --svg-text: #1a1a1a;
+        --svg-primary: #0066cc;
+        --svg-success: #16a34a;
+        --svg-warning: #ca8a04;
+        --svg-error: #dc2626;
+        --svg-neutral: #6b7280;
+      }
+      .title-text { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 16px; font-weight: 600; fill: var(--svg-text); }
+      .section-title { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 12px; font-weight: 500; fill: var(--svg-bg); }
+      .component-text { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 12px; font-weight: 400; fill: var(--svg-text); }
+      .annotation-text { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 10px; font-weight: 400; fill: var(--svg-neutral); }
+      .client-zone { fill: var(--svg-primary); stroke: var(--svg-primary); stroke-width: 2; }
+      .auth-zone { fill: var(--svg-warning); stroke: var(--svg-warning); stroke-width: 2; }
+      .database-zone { fill: var(--svg-success); stroke: var(--svg-success); stroke-width: 2; }
+      .jwt-zone { fill: var(--svg-error); stroke: var(--svg-error); stroke-width: 2; }
+      .auth-flow { stroke: var(--svg-primary); stroke-width: 2; fill: none; marker-end: url(#arrowhead); }
+      .data-flow { stroke: var(--svg-success); stroke-width: 2; stroke-dasharray: 5,3; fill: none; marker-end: url(#arrowhead-green); }
+    </style>
+    <marker id="arrowhead" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto">
+      <polygon points="0 0, 10 3, 0 6" fill="var(--svg-primary)"/>
+    </marker>
+    <marker id="arrowhead-green" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto">
+      <polygon points="0 0, 10 3, 0 6" fill="var(--svg-success)"/>
+    </marker>
+  </defs>
+
+  <!-- Title -->
+  <text x="400" y="30" class="title-text" text-anchor="middle">Supabase認証フローとRow Level Security</text>
+
+  <!-- Client Application -->
+  <g id="client-app">
+    <rect x="60" y="60" width="200" height="120" class="client-zone" rx="4"/>
+    <text x="160" y="80" class="section-title" text-anchor="middle">クライアントアプリケーション</text>
+    
+    <rect x="80" y="90" width="160" height="70" fill="var(--svg-bg)" stroke="var(--svg-primary)" stroke-width="1" rx="4"/>
+    <text x="160" y="110" class="component-text" text-anchor="middle" font-weight="500">React/Next.js App</text>
+    <text x="90" y="125" class="annotation-text">• ログインフォーム</text>
+    <text x="90" y="140" class="annotation-text">• Supabase Client SDK</text>
+    <text x="90" y="155" class="annotation-text">• セッション管理</text>
+  </g>
+
+  <!-- Auth Service -->
+  <g id="auth-service">
+    <rect x="300" y="60" width="200" height="180" class="auth-zone" rx="4"/>
+    <text x="400" y="80" class="section-title" text-anchor="middle">Supabase Auth Service</text>
+    
+    <!-- Auth Methods -->
+    <rect x="320" y="90" width="160" height="60" fill="var(--svg-bg)" stroke="var(--svg-warning)" stroke-width="1" rx="4"/>
+    <text x="400" y="110" class="component-text" text-anchor="middle" font-weight="500">認証方法</text>
+    <text x="330" y="125" class="annotation-text">• Email/Password</text>
+    <text x="330" y="140" class="annotation-text">• OAuth (Google/GitHub)</text>
+    
+    <!-- User Management -->
+    <rect x="320" y="160" width="160" height="60" fill="var(--svg-bg)" stroke="var(--svg-warning)" stroke-width="1" rx="4"/>
+    <text x="400" y="180" class="component-text" text-anchor="middle" font-weight="500">ユーザー管理</text>
+    <text x="330" y="195" class="annotation-text">• auth.users テーブル</text>
+    <text x="330" y="210" class="annotation-text">• メタデータ管理</text>
+  </g>
+
+  <!-- JWT Token -->
+  <g id="jwt-token">
+    <rect x="540" y="60" width="200" height="180" class="jwt-zone" rx="4"/>
+    <text x="640" y="80" class="section-title" text-anchor="middle">JWTトークン</text>
+    
+    <!-- Token Structure -->
+    <rect x="560" y="90" width="160" height="140" fill="var(--svg-bg)" stroke="var(--svg-error)" stroke-width="1" rx="4"/>
+    <text x="640" y="110" class="component-text" text-anchor="middle" font-weight="500">トークン構造</text>
+    <text x="570" y="125" class="annotation-text">Header:</text>
+    <text x="580" y="140" class="annotation-text">{ "alg": "HS256" }</text>
+    <text x="570" y="155" class="annotation-text">Payload:</text>
+    <text x="580" y="170" class="annotation-text">{ "sub": "user-id",</text>
+    <text x="580" y="185" class="annotation-text">  "role": "authenticated",</text>
+    <text x="580" y="200" class="annotation-text">  "exp": 1234567890 }</text>
+    <text x="570" y="215" class="annotation-text">Signature: [検証済み]</text>
+  </g>
+
+  <!-- Database with RLS -->
+  <g id="database-rls">
+    <rect x="180" y="260" width="440" height="180" class="database-zone" rx="4"/>
+    <text x="400" y="280" class="section-title" text-anchor="middle">PostgreSQL Database + Row Level Security</text>
+    
+    <!-- RLS Policies -->
+    <rect x="200" y="290" width="180" height="130" fill="var(--svg-bg)" stroke="var(--svg-success)" stroke-width="1" rx="4"/>
+    <text x="290" y="310" class="component-text" text-anchor="middle" font-weight="500">RLSポリシー</text>
+    <text x="210" y="325" class="annotation-text">SELECT Policy:</text>
+    <text x="220" y="340" class="annotation-text">auth.uid() = user_id</text>
+    <text x="210" y="355" class="annotation-text">INSERT Policy:</text>
+    <text x="220" y="370" class="annotation-text">auth.uid() = user_id</text>
+    <text x="210" y="385" class="annotation-text">UPDATE Policy:</text>
+    <text x="220" y="400" class="annotation-text">auth.uid() = user_id</text>
+    <text x="220" y="415" class="annotation-text">AND status != 'locked'</text>
+    
+    <!-- Data Tables -->
+    <rect x="400" y="290" width="200" height="130" fill="var(--svg-bg)" stroke="var(--svg-success)" stroke-width="1" rx="4"/>
+    <text x="500" y="310" class="component-text" text-anchor="middle" font-weight="500">データテーブル</text>
+    <text x="410" y="325" class="annotation-text">• profiles (ユーザープロファイル)</text>
+    <text x="410" y="340" class="annotation-text">• organizations (組織)</text>
+    <text x="410" y="355" class="annotation-text">• projects (プロジェクト)</text>
+    <text x="410" y="370" class="annotation-text">• permissions (権限)</text>
+    <text x="410" y="385" class="annotation-text">• audit_logs (監査ログ)</text>
+    <text x="410" y="400" class="annotation-text">• [RLS有効化済み]</text>
+  </g>
+
+  <!-- Authentication Flow Steps -->
+  <g id="auth-flow-steps">
+    <rect x="80" y="460" width="640" height="120" fill="var(--svg-neutral)" fill-opacity="0.05" stroke="var(--svg-text)" stroke-width="2" rx="4"/>
+    <text x="400" y="480" class="component-text" text-anchor="middle" font-weight="500">認証フロー</text>
+    
+    <!-- Step 1 -->
+    <rect x="100" y="490" width="100" height="70" fill="var(--svg-bg)" stroke="var(--svg-neutral)" stroke-width="1" rx="4"/>
+    <text x="150" y="510" class="component-text" text-anchor="middle" font-weight="500">1. ログイン</text>
+    <text x="110" y="525" class="annotation-text">ユーザー認証</text>
+    <text x="110" y="540" class="annotation-text">資格情報送信</text>
+    <text x="110" y="555" class="annotation-text">OAuth認証</text>
+    
+    <!-- Step 2 -->
+    <rect x="220" y="490" width="100" height="70" fill="var(--svg-bg)" stroke="var(--svg-neutral)" stroke-width="1" rx="4"/>
+    <text x="270" y="510" class="component-text" text-anchor="middle" font-weight="500">2. JWT生成</text>
+    <text x="230" y="525" class="annotation-text">トークン作成</text>
+    <text x="230" y="540" class="annotation-text">ロール付与</text>
+    <text x="230" y="555" class="annotation-text">有効期限設定</text>
+    
+    <!-- Step 3 -->
+    <rect x="340" y="490" width="100" height="70" fill="var(--svg-bg)" stroke="var(--svg-neutral)" stroke-width="1" rx="4"/>
+    <text x="390" y="510" class="component-text" text-anchor="middle" font-weight="500">3. API呼出</text>
+    <text x="350" y="525" class="annotation-text">JWTヘッダー付</text>
+    <text x="350" y="540" class="annotation-text">データリクエスト</text>
+    <text x="350" y="555" class="annotation-text">CRUD操作</text>
+    
+    <!-- Step 4 -->
+    <rect x="460" y="490" width="100" height="70" fill="var(--svg-bg)" stroke="var(--svg-neutral)" stroke-width="1" rx="4"/>
+    <text x="510" y="510" class="component-text" text-anchor="middle" font-weight="500">4. RLS適用</text>
+    <text x="470" y="525" class="annotation-text">JWT検証</text>
+    <text x="470" y="540" class="annotation-text">ポリシー評価</text>
+    <text x="470" y="555" class="annotation-text">データフィルタ</text>
+    
+    <!-- Step 5 -->
+    <rect x="580" y="490" width="120" height="70" fill="var(--svg-bg)" stroke="var(--svg-neutral)" stroke-width="1" rx="4"/>
+    <text x="640" y="510" class="component-text" text-anchor="middle" font-weight="500">5. レスポンス</text>
+    <text x="590" y="525" class="annotation-text">フィルタ済データ</text>
+    <text x="590" y="540" class="annotation-text">エラーハンドリング</text>
+    <text x="590" y="555" class="annotation-text">ステータスコード</text>
+  </g>
+
+  <!-- Flow Arrows -->
+  <path d="M 260 120 L 300 120" class="auth-flow"/>
+  <text x="280" y="115" class="annotation-text" text-anchor="middle">1. 認証要求</text>
+  
+  <path d="M 500 150 L 540 150" class="auth-flow"/>
+  <text x="520" y="145" class="annotation-text" text-anchor="middle">2. JWT発行</text>
+  
+  <path d="M 640 240 L 640 260 L 500 260" class="auth-flow"/>
+  <text x="570" y="255" class="annotation-text" text-anchor="middle">3. JWT付きリクエスト</text>
+  
+  <path d="M 400 440 L 400 460" class="data-flow"/>
+  <text x="420" y="455" class="annotation-text">4. RLS適用結果</text>
+  
+  <path d="M 260 160 L 160 180 L 160 460" class="data-flow"/>
+  <text x="180" y="320" class="annotation-text" text-anchor="middle">5. データ返却</text>
+</svg>

--- a/docs/assets/images/diagrams/caching-strategy.svg
+++ b/docs/assets/images/diagrams/caching-strategy.svg
@@ -1,0 +1,224 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="800" height="600" viewBox="0 0 800 600" xmlns="http://www.w3.org/2000/svg">
+  <title>Supabaseキャッシング戦略</title>
+  <desc>クライアント、Edge、データベースレベルでの包括的なキャッシング戦略とCDN統合</desc>
+  <defs>
+    <style>
+      :root {
+        --svg-bg: #ffffff;
+        --svg-text: #1a1a1a;
+        --svg-primary: #0066cc;
+        --svg-success: #16a34a;
+        --svg-warning: #ca8a04;
+        --svg-error: #dc2626;
+        --svg-neutral: #6b7280;
+      }
+      .title-text { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 16px; font-weight: 600; fill: var(--svg-text); }
+      .layer-title { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 12px; font-weight: 500; fill: var(--svg-bg); }
+      .cache-text { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 12px; font-weight: 400; fill: var(--svg-text); }
+      .annotation-text { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 10px; font-weight: 400; fill: var(--svg-neutral); }
+      .client-cache { fill: var(--svg-primary); stroke: var(--svg-primary); stroke-width: 2; }
+      .edge-cache { fill: var(--svg-warning); stroke: var(--svg-warning); stroke-width: 2; }
+      .db-cache { fill: var(--svg-success); stroke: var(--svg-success); stroke-width: 2; }
+      .cdn-layer { fill: var(--svg-error); stroke: var(--svg-error); stroke-width: 2; }
+      .cache-flow { stroke: var(--svg-primary); stroke-width: 2; fill: none; marker-end: url(#arrowhead); }
+      .invalidation-flow { stroke: var(--svg-error); stroke-width: 2; stroke-dasharray: 5,3; fill: none; marker-end: url(#arrowhead-red); }
+    </style>
+    <marker id="arrowhead" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto">
+      <polygon points="0 0, 10 3, 0 6" fill="var(--svg-primary)"/>
+    </marker>
+    <marker id="arrowhead-red" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto">
+      <polygon points="0 0, 10 3, 0 6" fill="var(--svg-error)"/>
+    </marker>
+  </defs>
+
+  <!-- Title -->
+  <text x="400" y="30" class="title-text" text-anchor="middle">Supabaseキャッシング戦略</text>
+
+  <!-- Client-side Cache Layer -->
+  <g id="client-cache">
+    <rect x="60" y="60" width="680" height="100" class="client-cache" rx="4"/>
+    <text x="400" y="80" class="layer-title" text-anchor="middle">クライアントサイドキャッシュ</text>
+    
+    <!-- Browser Cache -->
+    <rect x="80" y="90" width="120" height="50" fill="var(--svg-bg)" stroke="var(--svg-primary)" stroke-width="1" rx="4"/>
+    <text x="140" y="110" class="cache-text" text-anchor="middle" font-weight="500">ブラウザキャッシュ</text>
+    <text x="90" y="125" class="annotation-text">• LocalStorage</text>
+    <text x="90" y="135" class="annotation-text">• SessionStorage</text>
+    
+    <!-- React Query -->
+    <rect x="220" y="90" width="120" height="50" fill="var(--svg-bg)" stroke="var(--svg-primary)" stroke-width="1" rx="4"/>
+    <text x="280" y="110" class="cache-text" text-anchor="middle" font-weight="500">React Query</text>
+    <text x="230" y="125" class="annotation-text">• データ同期</text>
+    <text x="230" y="135" class="annotation-text">• 自動リフレッシュ</text>
+    
+    <!-- SWR Cache -->
+    <rect x="360" y="90" width="120" height="50" fill="var(--svg-bg)" stroke="var(--svg-primary)" stroke-width="1" rx="4"/>
+    <text x="420" y="110" class="cache-text" text-anchor="middle" font-weight="500">SWR</text>
+    <text x="370" y="125" class="annotation-text">• Stale-While-Revalidate</text>
+    <text x="370" y="135" class="annotation-text">• バックグラウンド更新</text>
+    
+    <!-- IndexedDB -->
+    <rect x="500" y="90" width="120" height="50" fill="var(--svg-bg)" stroke="var(--svg-primary)" stroke-width="1" rx="4"/>
+    <text x="560" y="110" class="cache-text" text-anchor="middle" font-weight="500">IndexedDB</text>
+    <text x="510" y="125" class="annotation-text">• 大容量データ</text>
+    <text x="510" y="135" class="annotation-text">• オフライン対応</text>
+    
+    <!-- Service Worker -->
+    <rect x="640" y="90" width="80" height="50" fill="var(--svg-bg)" stroke="var(--svg-primary)" stroke-width="1" rx="4"/>
+    <text x="680" y="110" class="cache-text" text-anchor="middle" font-weight="500">Service Worker</text>
+    <text x="650" y="125" class="annotation-text">• PWA</text>
+    <text x="650" y="135" class="annotation-text">• オフライン</text>
+  </g>
+
+  <!-- CDN Layer -->
+  <g id="cdn-layer">
+    <rect x="60" y="180" width="340" height="100" class="cdn-layer" rx="4"/>
+    <text x="230" y="200" class="layer-title" text-anchor="middle">CDN Layer</text>
+    
+    <!-- CloudFlare -->
+    <rect x="80" y="210" width="100" height="50" fill="var(--svg-bg)" stroke="var(--svg-error)" stroke-width="1" rx="4"/>
+    <text x="130" y="230" class="cache-text" text-anchor="middle" font-weight="500">CloudFlare</text>
+    <text x="90" y="245" class="annotation-text">• 静的アセット</text>
+    <text x="90" y="255" class="annotation-text">• API Cache</text>
+    
+    <!-- Fastly -->
+    <rect x="190" y="210" width="100" height="50" fill="var(--svg-bg)" stroke="var(--svg-error)" stroke-width="1" rx="4"/>
+    <text x="240" y="230" class="cache-text" text-anchor="middle" font-weight="500">Fastly</text>
+    <text x="200" y="245" class="annotation-text">• Edge Computing</text>
+    <text x="200" y="255" class="annotation-text">• リアルタイム配信</text>
+    
+    <!-- Storage CDN -->
+    <rect x="300" y="210" width="80" height="50" fill="var(--svg-bg)" stroke="var(--svg-error)" stroke-width="1" rx="4"/>
+    <text x="340" y="230" class="cache-text" text-anchor="middle" font-weight="500">Storage CDN</text>
+    <text x="310" y="245" class="annotation-text">• 画像/動画</text>
+    <text x="310" y="255" class="annotation-text">• ファイル</text>
+  </g>
+
+  <!-- Edge Functions Cache -->
+  <g id="edge-cache">
+    <rect x="420" y="180" width="320" height="100" class="edge-cache" rx="4"/>
+    <text x="580" y="200" class="layer-title" text-anchor="middle">Edge Functions キャッシュ</text>
+    
+    <!-- In-Memory Cache -->
+    <rect x="440" y="210" width="90" height="50" fill="var(--svg-bg)" stroke="var(--svg-warning)" stroke-width="1" rx="4"/>
+    <text x="485" y="230" class="cache-text" text-anchor="middle" font-weight="500">Memory Cache</text>
+    <text x="450" y="245" class="annotation-text">• 高速アクセス</text>
+    <text x="450" y="255" class="annotation-text">• TTL管理</text>
+    
+    <!-- Redis Edge -->
+    <rect x="540" y="210" width="90" height="50" fill="var(--svg-bg)" stroke="var(--svg-warning)" stroke-width="1" rx="4"/>
+    <text x="585" y="230" class="cache-text" text-anchor="middle" font-weight="500">Redis Edge</text>
+    <text x="550" y="245" class="annotation-text">• 分散キャッシュ</text>
+    <text x="550" y="255" class="annotation-text">• セッション</text>
+    
+    <!-- Response Cache -->
+    <rect x="640" y="210" width="80" height="50" fill="var(--svg-bg)" stroke="var(--svg-warning)" stroke-width="1" rx="4"/>
+    <text x="680" y="230" class="cache-text" text-anchor="middle" font-weight="500">Response</text>
+    <text x="650" y="245" class="annotation-text">• API結果</text>
+    <text x="650" y="255" class="annotation-text">• JSON</text>
+  </g>
+
+  <!-- Database Cache Layer -->
+  <g id="db-cache">
+    <rect x="60" y="300" width="680" height="120" class="db-cache" rx="4"/>
+    <text x="400" y="320" class="layer-title" text-anchor="middle">データベースレベルキャッシュ</text>
+    
+    <!-- Query Cache -->
+    <rect x="80" y="330" width="120" height="70" fill="var(--svg-bg)" stroke="var(--svg-success)" stroke-width="1" rx="4"/>
+    <text x="140" y="350" class="cache-text" text-anchor="middle" font-weight="500">Query Cache</text>
+    <text x="90" y="365" class="annotation-text">• 結果セット</text>
+    <text x="90" y="380" class="annotation-text">• プリペアード</text>
+    <text x="90" y="395" class="annotation-text">• 実行計画</text>
+    
+    <!-- Connection Pool -->
+    <rect x="220" y="330" width="120" height="70" fill="var(--svg-bg)" stroke="var(--svg-success)" stroke-width="1" rx="4"/>
+    <text x="280" y="350" class="cache-text" text-anchor="middle" font-weight="500">Connection Pool</text>
+    <text x="230" y="365" class="annotation-text">• PgBouncer</text>
+    <text x="230" y="380" class="annotation-text">• 接続再利用</text>
+    <text x="230" y="395" class="annotation-text">• トランザクション</text>
+    
+    <!-- Materialized Views -->
+    <rect x="360" y="330" width="120" height="70" fill="var(--svg-bg)" stroke="var(--svg-success)" stroke-width="1" rx="4"/>
+    <text x="420" y="350" class="cache-text" text-anchor="middle" font-weight="500">Materialized View</text>
+    <text x="370" y="365" class="annotation-text">• 事前計算</text>
+    <text x="370" y="380" class="annotation-text">• 集計データ</text>
+    <text x="370" y="395" class="annotation-text">• 定期更新</text>
+    
+    <!-- Redis Cache -->
+    <rect x="500" y="330" width="120" height="70" fill="var(--svg-bg)" stroke="var(--svg-success)" stroke-width="1" rx="4"/>
+    <text x="560" y="350" class="cache-text" text-anchor="middle" font-weight="500">Redis Cache</text>
+    <text x="510" y="365" class="annotation-text">• セッション</text>
+    <text x="510" y="380" class="annotation-text">• 頻繁アクセス</text>
+    <text x="510" y="395" class="annotation-text">• リアルタイムデータ</text>
+    
+    <!-- Buffer Cache -->
+    <rect x="640" y="330" width="80" height="70" fill="var(--svg-bg)" stroke="var(--svg-success)" stroke-width="1" rx="4"/>
+    <text x="680" y="350" class="cache-text" text-anchor="middle" font-weight="500">Buffer</text>
+    <text x="650" y="365" class="annotation-text">• ページキャッシュ</text>
+    <text x="650" y="380" class="annotation-text">• WAL</text>
+    <text x="650" y="395" class="annotation-text">• インデックス</text>
+  </g>
+
+  <!-- Cache Invalidation Strategy -->
+  <g id="invalidation-strategy">
+    <rect x="60" y="440" width="340" height="140" fill="var(--svg-error)" fill-opacity="0.05" stroke="var(--svg-error)" stroke-width="2" rx="4"/>
+    <text x="230" y="460" class="cache-text" text-anchor="middle" font-weight="500">キャッシュ無効化戦略</text>
+    
+    <!-- TTL Based -->
+    <rect x="80" y="470" width="100" height="90" fill="var(--svg-bg)" stroke="var(--svg-error)" stroke-width="1" rx="4"/>
+    <text x="130" y="490" class="cache-text" text-anchor="middle" font-weight="500">TTLベース</text>
+    <text x="90" y="505" class="annotation-text">• 時間経過</text>
+    <text x="90" y="520" class="annotation-text">• 自動失効</text>
+    <text x="90" y="535" class="annotation-text">• シンプル</text>
+    <text x="90" y="550" class="annotation-text">• 遅延可能性</text>
+    
+    <!-- Event Based -->
+    <rect x="190" y="470" width="100" height="90" fill="var(--svg-bg)" stroke="var(--svg-error)" stroke-width="1" rx="4"/>
+    <text x="240" y="490" class="cache-text" text-anchor="middle" font-weight="500">イベント駆動</text>
+    <text x="200" y="505" class="annotation-text">• DB Trigger</text>
+    <text x="200" y="520" class="annotation-text">• Webhook</text>
+    <text x="200" y="535" class="annotation-text">• リアルタイム</text>
+    <text x="200" y="550" class="annotation-text">• 複雑</text>
+    
+    <!-- Manual -->
+    <rect x="300" y="470" width="80" height="90" fill="var(--svg-bg)" stroke="var(--svg-error)" stroke-width="1" rx="4"/>
+    <text x="340" y="490" class="cache-text" text-anchor="middle" font-weight="500">手動無効化</text>
+    <text x="310" y="505" class="annotation-text">• API呼出</text>
+    <text x="310" y="520" class="annotation-text">• 管理画面</text>
+    <text x="310" y="535" class="annotation-text">• 即座</text>
+    <text x="310" y="550" class="annotation-text">• 運用負荷</text>
+  </g>
+
+  <!-- Performance Metrics -->
+  <g id="performance-metrics">
+    <rect x="420" y="440" width="320" height="140" fill="var(--svg-primary)" fill-opacity="0.05" stroke="var(--svg-primary)" stroke-width="2" rx="4"/>
+    <text x="580" y="460" class="cache-text" text-anchor="middle" font-weight="500">パフォーマンス指標</text>
+    
+    <!-- Hit Rate -->
+    <rect x="440" y="470" width="140" height="40" fill="var(--svg-bg)" stroke="var(--svg-primary)" stroke-width="1" rx="4"/>
+    <text x="510" y="490" class="cache-text" text-anchor="middle" font-weight="500">キャッシュヒット率</text>
+    <text x="510" y="505" class="annotation-text" text-anchor="middle">目標: >90%</text>
+    
+    <!-- Latency -->
+    <rect x="590" y="470" width="130" height="40" fill="var(--svg-bg)" stroke="var(--svg-primary)" stroke-width="1" rx="4"/>
+    <text x="655" y="490" class="cache-text" text-anchor="middle" font-weight="500">レイテンシ削減</text>
+    <text x="655" y="505" class="annotation-text" text-anchor="middle">50-80% 改善</text>
+    
+    <!-- Bandwidth -->
+    <rect x="440" y="520" width="140" height="40" fill="var(--svg-bg)" stroke="var(--svg-primary)" stroke-width="1" rx="4"/>
+    <text x="510" y="540" class="cache-text" text-anchor="middle" font-weight="500">帯域幅削減</text>
+    <text x="510" y="555" class="annotation-text" text-anchor="middle">60-70% 削減</text>
+    
+    <!-- Cost -->
+    <rect x="590" y="520" width="130" height="40" fill="var(--svg-bg)" stroke="var(--svg-primary)" stroke-width="1" rx="4"/>
+    <text x="655" y="540" class="cache-text" text-anchor="middle" font-weight="500">コスト削減</text>
+    <text x="655" y="555" class="annotation-text" text-anchor="middle">DB負荷軽減</text>
+  </g>
+
+  <!-- Cache Flow Arrows -->
+  <path d="M 400 160 L 400 180" class="cache-flow"/>
+  <path d="M 400 280 L 400 300" class="cache-flow"/>
+  <path d="M 230 280 L 230 440" class="invalidation-flow"/>
+  <text x="240" y="360" class="annotation-text">無効化</text>
+</svg>

--- a/docs/assets/images/diagrams/multi-tenancy-model.svg
+++ b/docs/assets/images/diagrams/multi-tenancy-model.svg
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="800" height="600" viewBox="0 0 800 600" xmlns="http://www.w3.org/2000/svg">
+  <title>Supabaseマルチテナンシーモデル</title>
+  <desc>スキーマ分離、行レベル分離、データベース分離の各マルチテナンシー戦略</desc>
+  <defs>
+    <style>
+      :root {
+        --svg-bg: #ffffff;
+        --svg-text: #1a1a1a;
+        --svg-primary: #0066cc;
+        --svg-success: #16a34a;
+        --svg-warning: #ca8a04;
+        --svg-error: #dc2626;
+        --svg-neutral: #6b7280;
+      }
+      .title-text { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 16px; font-weight: 600; fill: var(--svg-text); }
+      .model-title { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 12px; font-weight: 500; fill: var(--svg-bg); }
+      .component-text { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 12px; font-weight: 400; fill: var(--svg-text); }
+      .annotation-text { font-family: Inter, 'Helvetica Neue', Arial, sans-serif; font-size: 10px; font-weight: 400; fill: var(--svg-neutral); }
+      .schema-model { fill: var(--svg-primary); stroke: var(--svg-primary); stroke-width: 2; }
+      .row-model { fill: var(--svg-warning); stroke: var(--svg-warning); stroke-width: 2; }
+      .database-model { fill: var(--svg-success); stroke: var(--svg-success); stroke-width: 2; }
+      .tenant-box { fill: var(--svg-error); fill-opacity: 0.1; stroke: var(--svg-error); stroke-width: 1; }
+      .security-layer { fill: var(--svg-neutral); stroke: var(--svg-neutral); stroke-width: 2; }
+    </style>
+  </defs>
+
+  <!-- Title -->
+  <text x="400" y="30" class="title-text" text-anchor="middle">Supabaseマルチテナンシーモデル</text>
+
+  <!-- Schema-based Isolation -->
+  <g id="schema-isolation">
+    <rect x="60" y="60" width="220" height="200" class="schema-model" rx="4"/>
+    <text x="170" y="80" class="model-title" text-anchor="middle">スキーマベース分離</text>
+    
+    <!-- Database Structure -->
+    <rect x="80" y="90" width="180" height="160" fill="var(--svg-bg)" stroke="var(--svg-primary)" stroke-width="1" rx="4"/>
+    <text x="170" y="110" class="component-text" text-anchor="middle" font-weight="500">単一データベース</text>
+    
+    <!-- Tenant Schemas -->
+    <rect x="90" y="120" width="70" height="40" class="tenant-box" rx="2"/>
+    <text x="125" y="135" class="annotation-text" text-anchor="middle">Schema A</text>
+    <text x="125" y="150" class="annotation-text" text-anchor="middle">Tenant 1</text>
+    
+    <rect x="170" y="120" width="70" height="40" class="tenant-box" rx="2"/>
+    <text x="205" y="135" class="annotation-text" text-anchor="middle">Schema B</text>
+    <text x="205" y="150" class="annotation-text" text-anchor="middle">Tenant 2</text>
+    
+    <rect x="90" y="170" width="70" height="40" class="tenant-box" rx="2"/>
+    <text x="125" y="185" class="annotation-text" text-anchor="middle">Schema C</text>
+    <text x="125" y="200" class="annotation-text" text-anchor="middle">Tenant 3</text>
+    
+    <rect x="170" y="170" width="70" height="40" class="tenant-box" rx="2"/>
+    <text x="205" y="185" class="annotation-text" text-anchor="middle">Public</text>
+    <text x="205" y="200" class="annotation-text" text-anchor="middle">共通データ</text>
+    
+    <text x="170" y="230" class="annotation-text" text-anchor="middle">search_path切替</text>
+    <text x="170" y="245" class="annotation-text" text-anchor="middle">論理的分離</text>
+  </g>
+
+  <!-- Row-level Isolation -->
+  <g id="row-isolation">
+    <rect x="290" y="60" width="220" height="200" class="row-model" rx="4"/>
+    <text x="400" y="80" class="model-title" text-anchor="middle">行レベル分離 (RLS)</text>
+    
+    <!-- Database Structure -->
+    <rect x="310" y="90" width="180" height="160" fill="var(--svg-bg)" stroke="var(--svg-warning)" stroke-width="1" rx="4"/>
+    <text x="400" y="110" class="component-text" text-anchor="middle" font-weight="500">共有テーブル</text>
+    
+    <!-- Data Rows with Tenant ID -->
+    <rect x="320" y="120" width="160" height="25" fill="var(--svg-bg)" stroke="var(--svg-warning)" stroke-width="1" rx="2"/>
+    <text x="330" y="137" class="annotation-text">Row 1 | tenant_id: A | data...</text>
+    
+    <rect x="320" y="150" width="160" height="25" fill="var(--svg-bg)" stroke="var(--svg-warning)" stroke-width="1" rx="2"/>
+    <text x="330" y="167" class="annotation-text">Row 2 | tenant_id: B | data...</text>
+    
+    <rect x="320" y="180" width="160" height="25" fill="var(--svg-bg)" stroke="var(--svg-warning)" stroke-width="1" rx="2"/>
+    <text x="330" y="197" class="annotation-text">Row 3 | tenant_id: A | data...</text>
+    
+    <rect x="320" y="210" width="160" height="25" fill="var(--svg-bg)" stroke="var(--svg-warning)" stroke-width="1" rx="2"/>
+    <text x="330" y="227" class="annotation-text">Row 4 | tenant_id: C | data...</text>
+    
+    <text x="400" y="245" class="annotation-text" text-anchor="middle">RLSポリシーで自動フィルタ</text>
+  </g>
+
+  <!-- Database-level Isolation -->
+  <g id="database-isolation">
+    <rect x="520" y="60" width="220" height="200" class="database-model" rx="4"/>
+    <text x="630" y="80" class="model-title" text-anchor="middle">データベースレベル分離</text>
+    
+    <!-- Multiple Databases -->
+    <rect x="540" y="90" width="80" height="50" fill="var(--svg-bg)" stroke="var(--svg-success)" stroke-width="1" rx="4"/>
+    <text x="580" y="110" class="component-text" text-anchor="middle" font-weight="500">DB-A</text>
+    <text x="580" y="125" class="annotation-text" text-anchor="middle">Tenant 1</text>
+    
+    <rect x="640" y="90" width="80" height="50" fill="var(--svg-bg)" stroke="var(--svg-success)" stroke-width="1" rx="4"/>
+    <text x="680" y="110" class="component-text" text-anchor="middle" font-weight="500">DB-B</text>
+    <text x="680" y="125" class="annotation-text" text-anchor="middle">Tenant 2</text>
+    
+    <rect x="540" y="150" width="80" height="50" fill="var(--svg-bg)" stroke="var(--svg-success)" stroke-width="1" rx="4"/>
+    <text x="580" y="170" class="component-text" text-anchor="middle" font-weight="500">DB-C</text>
+    <text x="580" y="185" class="annotation-text" text-anchor="middle">Tenant 3</text>
+    
+    <rect x="640" y="150" width="80" height="50" fill="var(--svg-bg)" stroke="var(--svg-success)" stroke-width="1" rx="4"/>
+    <text x="680" y="170" class="component-text" text-anchor="middle" font-weight="500">DB-D</text>
+    <text x="680" y="185" class="annotation-text" text-anchor="middle">Tenant 4</text>
+    
+    <text x="630" y="215" class="annotation-text" text-anchor="middle">完全物理分離</text>
+    <text x="630" y="230" class="annotation-text" text-anchor="middle">独立接続</text>
+    <text x="630" y="245" class="annotation-text" text-anchor="middle">最高セキュリティ</text>
+  </g>
+
+  <!-- Comparison Matrix -->
+  <g id="comparison-matrix">
+    <rect x="60" y="280" width="680" height="160" fill="var(--svg-neutral)" fill-opacity="0.05" stroke="var(--svg-text)" stroke-width="2" rx="4"/>
+    <text x="400" y="300" class="component-text" text-anchor="middle" font-weight="500">マルチテナンシーモデル比較</text>
+    
+    <!-- Headers -->
+    <text x="140" y="320" class="component-text" font-weight="500">評価項目</text>
+    <text x="300" y="320" class="component-text" text-anchor="middle">スキーマ分離</text>
+    <text x="450" y="320" class="component-text" text-anchor="middle">行レベル分離</text>
+    <text x="600" y="320" class="component-text" text-anchor="middle">DB分離</text>
+    
+    <!-- Isolation Level -->
+    <text x="140" y="340" class="annotation-text">分離レベル</text>
+    <text x="300" y="340" class="annotation-text" text-anchor="middle">中</text>
+    <text x="450" y="340" class="annotation-text" text-anchor="middle">低</text>
+    <text x="600" y="340" class="annotation-text" text-anchor="middle">高</text>
+    
+    <!-- Scalability -->
+    <text x="140" y="360" class="annotation-text">スケーラビリティ</text>
+    <text x="300" y="360" class="annotation-text" text-anchor="middle">中 (～1000)</text>
+    <text x="450" y="360" class="annotation-text" text-anchor="middle">高 (～10000)</text>
+    <text x="600" y="360" class="annotation-text" text-anchor="middle">低 (～100)</text>
+    
+    <!-- Cost -->
+    <text x="140" y="380" class="annotation-text">コスト</text>
+    <text x="300" y="380" class="annotation-text" text-anchor="middle">中</text>
+    <text x="450" y="380" class="annotation-text" text-anchor="middle">低</text>
+    <text x="600" y="380" class="annotation-text" text-anchor="middle">高</text>
+    
+    <!-- Management -->
+    <text x="140" y="400" class="annotation-text">管理複雑度</text>
+    <text x="300" y="400" class="annotation-text" text-anchor="middle">中</text>
+    <text x="450" y="400" class="annotation-text" text-anchor="middle">低</text>
+    <text x="600" y="400" class="annotation-text" text-anchor="middle">高</text>
+    
+    <!-- Customization -->
+    <text x="140" y="420" class="annotation-text">カスタマイズ性</text>
+    <text x="300" y="420" class="annotation-text" text-anchor="middle">中</text>
+    <text x="450" y="420" class="annotation-text" text-anchor="middle">低</text>
+    <text x="600" y="420" class="annotation-text" text-anchor="middle">高</text>
+  </g>
+
+  <!-- Security Considerations -->
+  <g id="security-considerations">
+    <rect x="80" y="460" width="640" height="120" class="security-layer" rx="4"/>
+    <text x="400" y="480" class="model-title" text-anchor="middle">セキュリティ実装</text>
+    
+    <!-- Schema Security -->
+    <rect x="100" y="490" width="180" height="70" fill="var(--svg-bg)" stroke="var(--svg-neutral)" stroke-width="1" rx="4"/>
+    <text x="190" y="510" class="component-text" text-anchor="middle" font-weight="500">スキーマ分離</text>
+    <text x="110" y="525" class="annotation-text">• GRANT/REVOKE制御</text>
+    <text x="110" y="540" class="annotation-text">• search_path制限</text>
+    <text x="110" y="555" class="annotation-text">• デフォルト権限設定</text>
+    
+    <!-- RLS Security -->
+    <rect x="310" y="490" width="180" height="70" fill="var(--svg-bg)" stroke="var(--svg-neutral)" stroke-width="1" rx="4"/>
+    <text x="400" y="510" class="component-text" text-anchor="middle" font-weight="500">RLS実装</text>
+    <text x="320" y="525" class="annotation-text">• auth.uid()ベース制御</text>
+    <text x="320" y="540" class="annotation-text">• テナントIDポリシー</text>
+    <text x="320" y="555" class="annotation-text">• 動的フィルタリング</text>
+    
+    <!-- Database Security -->
+    <rect x="520" y="490" width="180" height="70" fill="var(--svg-bg)" stroke="var(--svg-neutral)" stroke-width="1" rx="4"/>
+    <text x="610" y="510" class="component-text" text-anchor="middle" font-weight="500">DB分離</text>
+    <text x="530" y="525" class="annotation-text">• 独立した認証</text>
+    <text x="530" y="540" class="annotation-text">• ネットワーク分離</text>
+    <text x="530" y="555" class="annotation-text">• バックアップ分離</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
Issue #16で提案されたSupabaseアーキテクチャパターンの視覚化を実装しました。

## 追加した図表
1. **認証フローとRLS図** (`auth-flow-rls.svg`)
   - ユーザー認証フロー
   - JWTトークンライフサイクル
   - Row Level Security適用プロセス

2. **アーキテクチャ比較図** (`architecture-comparison.svg`)
   - クライアントサイド直接接続
   - Edge Functionsパターン
   - APIサーバーパターン
   - パフォーマンス比較マトリックス

3. **マルチテナンシーモデル図** (`multi-tenancy-model.svg`)
   - スキーマレベル分離
   - 行レベル分離(RLS)
   - データベースレベル分離
   - セキュリティ実装戦略

4. **キャッシング戦略図** (`caching-strategy.svg`)
   - クライアントサイドキャッシュ
   - CDN統合
   - Edge Functionsキャッシュ
   - データベースレベルキャッシュ

## 技術仕様
- SVG形式（800x600 viewBox）
- book-formatter互換
- CSS custom propertiesによるテーマ対応
- 日本語技術用語使用

Closes #16

🤖 Generated with [Claude Code](https://claude.ai/code)