### PR TITLE
docs: 内部リンク方針の統一（Phase #33）

### DIFF
--- a/docs/chapters/chapter03/index.md
+++ b/docs/chapters/chapter03/index.md
@@ -6,9 +6,9 @@ title: "第3章：パターン1 - クライアントサイド実装"
 # Chapter 3: パターン1 - クライアントサイド実装 🏠
 
 ---
-**📚 目次に戻る**: [📖 学習ガイド]({{ site.baseurl }}/introduction/index.html)  
-**⬅️ 前の章**: [Chapter 2: 認証システムの実装]({{ site.baseurl }}/chapters/chapter02/index.html)  
-**➡️ 次の章**: [Chapter 4: Edge Functions活用]({{ site.baseurl }}/chapters/chapter04/index.html)  
+**📚 目次に戻る**: [📖 学習ガイド]({{ '/introduction/' | relative_url }})  
+**⬅️ 前の章**: [Chapter 2: 認証システムの実装]({{ '/chapters/chapter02/' | relative_url }})  
+**➡️ 次の章**: [Chapter 4: Edge Functions活用]({{ '/chapters/chapter04/' | relative_url }})  
 **🎯 学習レベル**: 🌱 基礎 ➜ 🚀 応用  
 **⏱️ 推定学習時間**: 6-10時間  
 **🏗️ アーキテクチャ**: 木造住宅工法（シンプル・高速・個人向け）
@@ -24,7 +24,7 @@ Chapter 2で学んだ**認証・認可の基本概念**を振り返りましょ�
 
 これらのセキュリティ基盤を使って、今度は**実際に動くアプリケーション**を作成します。
 
-> 💡 **Chapter 2の理解度確認**: 認証と認可の違い、RLSの役割を説明できますか？不安な場合は[Chapter 2]({{ site.baseurl }}/chapters/chapter02/index.html)を復習してください。
+> 💡 **Chapter 2の理解度確認**: 認証と認可の違い、RLSの役割を説明できますか？不安な場合は[Chapter 2]({{ '/chapters/chapter02/' | relative_url }})を復習してください。
 
 ## 🎯 この章で学ぶこと（初心者向け）
 
@@ -2178,9 +2178,9 @@ def main(page: ft.Page):
 
 ### 復習推奨ポイント
 理解が不十分な場合は以下を復習してください：
-- **認証実装**: [Chapter 2: 認証・認可設計]({{ site.baseurl }}/chapters/chapter02/index.html)を確認
-- **RLS設計**: [セキュリティ強化]({{ site.baseurl }}/chapters/chapter07/index.html)で詳細学習
-- **パフォーマンス**: [Chapter 6: パフォーマンス最適化]({{ site.baseurl }}/chapters/chapter06/index.html)で深掘り
+- **認証実装**: [Chapter 2: 認証・認可設計]({{ '/chapters/chapter02/' | relative_url }})を確認
+- **RLS設計**: [セキュリティ強化]({{ '/chapters/chapter07/' | relative_url }})で詳細学習
+- **パフォーマンス**: [Chapter 6: パフォーマンス最適化]({{ '/chapters/chapter06/' | relative_url }})で深掘り
 
 ### 関連リソース
 - [Flet公式ドキュメント](https://flet.dev/docs/)
@@ -2193,7 +2193,7 @@ def main(page: ft.Page):
 
 | 前の章 | 現在の章 | 次の章 |
 |---------|----------|--------|
-| [Chapter 2: 認証・認可設計]({{ site.baseurl }}/chapters/chapter02/index.html) | **Chapter 3: クライアントサイド実装** | [Chapter 4: Edge Functions実装]({{ site.baseurl }}/chapters/chapter04/index.html) |
+| [Chapter 2: 認証・認可設計]({{ '/chapters/chapter02/' | relative_url }}) | **Chapter 3: クライアントサイド実装** | [Chapter 4: Edge Functions実装]({{ '/chapters/chapter04/' | relative_url }}) |
 
 ### 学習パス確認
 
@@ -2207,9 +2207,9 @@ flowchart LR
 ```
 
 ### 関連章への参照
-- **前提となる章**: [Chapter 2]({{ site.baseurl }}/chapters/chapter02/index.html) - 認証・認可基礎
-- **並行学習可能**: [Chapter 4]({{ site.baseurl }}/chapters/chapter04/index.html) - Edge Functions
-- **後続の発展**: [Chapter 6]({{ site.baseurl }}/chapters/chapter06/index.html) - パフォーマンス最適化
+- **前提となる章**: [Chapter 2]({{ '/chapters/chapter02/' | relative_url }}) - 認証・認可基礎
+- **並行学習可能**: [Chapter 4]({{ '/chapters/chapter04/' | relative_url }}) - Edge Functions
+- **後続の発展**: [Chapter 6]({{ '/chapters/chapter06/' | relative_url }}) - パフォーマンス最適化
 
 ## 📝 Chapter 3 学習まとめ
 
@@ -2324,14 +2324,14 @@ Chapter 4では、「病院薬剤管理システム」を例に、**プレハブ
 ---
 
 **📍 ナビゲーション**
-- **📚 目次**: [📖 学習ガイド]({{ site.baseurl }}/introduction/index.html)
-- **⬅️ 前の章**: [Chapter 2: 認証システム]({{ site.baseurl }}/chapters/chapter02/index.html)
-- **➡️ 次の章**: [Chapter 4: Edge Functions活用]({{ site.baseurl }}/chapters/chapter04/index.html)
-- **🏠 同レベル**: [Chapter 5: API Server実装]({{ site.baseurl }}/chapter05-1.md)
+- **📚 目次**: [📖 学習ガイド]({{ '/introduction/' | relative_url }})
+- **⬅️ 前の章**: [Chapter 2: 認証システム]({{ '/chapters/chapter02/' | relative_url }})
+- **➡️ 次の章**: [Chapter 4: Edge Functions活用]({{ '/chapters/chapter04/' | relative_url }})
+- **🏠 同レベル**: [Chapter 5: API Server実装]({{ '/chapter05-1.html' | relative_url }})
 - **🔧 実践**: [サンプルコード]({{ site.baseurl }}/src/chapter03-task-manager/) | [動作検証]({{ site.baseurl }}/src/verify_apps.py)
 
 ### 📚 **関連リソース**
-- 🔧 [トラブルシューティング]({{ site.baseurl }}/troubleshooting_guide.md)
-- 🎯 [パターン選択ガイド]({{ site.baseurl }}/pattern_selection_guide.md)  
-- 📋 [運用チェックリスト]({{ site.baseurl }}/operational_checklists.md)
+- 🔧 [トラブルシューティング]({{ '/troubleshooting_guide.html' | relative_url }})
+- 🎯 [パターン選択ガイド]({{ '/pattern_selection_guide.html' | relative_url }})  
+- 📋 [運用チェックリスト]({{ '/operational_checklists.html' | relative_url }})
 - 🔍 [コード検証ガイド]({{ site.baseurl }}/code_verification.md)

--- a/docs/chapters/chapter05-2/index.md
+++ b/docs/chapters/chapter05-2/index.md
@@ -7,8 +7,8 @@ title: "第5-2章：マルチテナンシーと複雑ビジネスロジック"
 
 ---
 **📚 目次に戻る**: [📖 学習ガイド]({{ site.baseurl }}/introduction/index.html)  
-**⬅️ 前の章**: [Chapter 5-1: 独立APIサーバー基礎]({{ site.baseurl }}/chapter05-1.md)  
-**➡️ 次の章**: [Chapter 5-3: 本番運用機能]({{ site.baseurl }}/chapter05-3.md)  
+**⬅️ 前の章**: [Chapter 5-1: 独立APIサーバー基礎]({{ '/chapter05-1.html' | relative_url }})  
+**➡️ 次の章**: [Chapter 5-3: 本番運用機能]({{ '/chapter05-3.html' | relative_url }})  
 **🏗️ アーキテクチャ**: 独立APIサーバー（FastAPI + マルチテナント）  
 **🎯 学習レベル**: 🌱 基礎 | 🚀 応用 | 💪 発展  
 **⏱️ 推定学習時間**: 4-6時間  
@@ -1784,8 +1784,8 @@ Chapter 5-3で学ぶ本番運用機能の前提知識：
 ---
 
 **📍 ナビゲーション**
-- **📚 目次**: [📖 学習ガイド]({{ site.baseurl }}/introduction/index.html)
-- **⬅️ 前の章**: [Chapter 5-1: 独立APIサーバー基礎]({{ site.baseurl }}/chapter05-1.md)  
-- **➡️ 次の章**: [Chapter 5-3: 本番運用機能]({{ site.baseurl }}/chapter05-3.md)
-- **🏠 関連章**: [Chapter 6: パフォーマンス最適化]({{ site.baseurl }}/chapters/chapter06/index.html) | [Chapter 8: 運用監視]({{ site.baseurl }}/chapters/chapter08/index.html)
-- **🔧 リソース**: [マルチテナント設計]({{ site.baseurl }}/src/) | [運用チェックリスト]({{ site.baseurl }}/operational_checklists.md)
+- **📚 目次**: [📖 学習ガイド]({{ '/introduction/' | relative_url }})
+- **⬅️ 前の章**: [Chapter 5-1: 独立APIサーバー基礎]({{ '/chapter05-1.html' | relative_url }})  
+- **➡️ 次の章**: [Chapter 5-3: 本番運用機能]({{ '/chapter05-3.html' | relative_url }})
+- **🏠 関連章**: [Chapter 6: パフォーマンス最適化]({{ '/chapters/chapter06/' | relative_url }}) | [Chapter 8: 運用監視]({{ '/chapters/chapter08/' | relative_url }})
+- **🔧 リソース**: [マルチテナント設計]({{ '/src/' | relative_url }}) | [運用チェックリスト]({{ '/operational_checklists.html' | relative_url }})

--- a/docs/guides/glossary/index.md
+++ b/docs/guides/glossary/index.md
@@ -6,7 +6,7 @@ title: "用語辞典"
 # 技術用語索引・用語集 📚
 
 ---
-**📚 目次に戻る**: [📖 学習ガイド]({{ site.baseurl }}/introduction/index.html)  
+**📚 目次に戻る**: [📖 学習ガイド]({{ '/introduction/' | relative_url }})  
 **🎯 用途**: 学習中の技術用語の即座な確認・復習  
 **📝 対象**: 全レベル（基礎〜上級）  
 **⏱️ 利用方法**: 不明な用語が出てきた時に参照  
@@ -59,14 +59,14 @@ title: "用語辞典"
 - **定義**: 「あなたは誰ですか？」を確認する仕組み
 - **Supabaseでの実装**: Supabase Auth + JWT
 - **実用例**: ログイン・パスワード確認
-- **参照章**: [Chapter 2: 認証・認可設計]({{ site.baseurl }}/chapters/chapter02/index.html)
+- **参照章**: [Chapter 2: 認証・認可設計]({{ '/chapters/chapter02/' | relative_url }})
 
 #### **Authorization（認可）**
 `#auth` `#security`
 - **定義**: 「何をする権限がありますか？」を制御する仕組み
 - **Supabaseでの実装**: RLS（Row Level Security）
 - **実用例**: 管理者のみが削除可能
-- **参照章**: [Chapter 2: 認証・認可設計]({{ site.baseurl }}/chapters/chapter02/index.html)
+- **参照章**: [Chapter 2: 認証・認可設計]({{ '/chapters/chapter02/' | relative_url }})
 
 ### B
 
@@ -75,7 +75,7 @@ title: "用語辞典"
 - **定義**: バックエンド機能をクラウドサービスとして提供する形態
 - **Supabaseでの位置づけ**: オープンソースBaaS
 - **実用例**: データベース・認証・ストレージを統合提供
-- **参照章**: [Chapter 1: Supabase概要]({{ site.baseurl }}/chapters/chapter01/index.html)
+- **参照章**: [Chapter 1: Supabase概要]({{ '/chapters/chapter01/' | relative_url }})
 
 ### C
 
@@ -84,14 +84,14 @@ title: "用語辞典"
 - **定義**: Create（作成）・Read（読み取り）・Update（更新）・Delete（削除）の4つの基本操作
 - **Supabaseでの実装**: PostgRESTが自動でCRUD APIを生成
 - **実用例**: ブログ記事の作成・表示・編集・削除
-- **参照章**: [Chapter 3: クライアントサイド実装]({{ site.baseurl }}/chapters/chapter03/index.html)
+- **参照章**: [Chapter 3: クライアントサイド実装]({{ '/chapters/chapter03/' | relative_url }})
 
 #### **CI/CD**
 `#deployment` `#automation`
 - **定義**: 継続的インテグレーション・継続的デプロイメント
 - **Supabaseでの実装**: GitHub Actions + Supabase CLI
 - **実用例**: コード変更の自動テスト・自動デプロイ
-- **参照章**: [Chapter 5-3: 本番運用]({{ site.baseurl }}/chapter05-3.md)
+- **参照章**: [Chapter 5-3: 本番運用]({{ '/chapter05-3.html' | relative_url }})
 
 ### D
 
@@ -100,7 +100,7 @@ title: "用語辞典"
 - **定義**: TypeScript/JavaScriptのモダンなランタイム環境
 - **Supabaseでの実装**: Edge Functions実行環境
 - **実用例**: サーバーレス関数の実行
-- **参照章**: [Chapter 4: Edge Functions]({{ site.baseurl }}/chapters/chapter04/index.html)
+- **参照章**: [Chapter 4: Edge Functions]({{ '/chapters/chapter04/' | relative_url }})
 
 #### **Docker**
 `#containerization` `#deployment`
@@ -116,7 +116,7 @@ title: "用語辞典"
 - **定義**: CDNエッジで実行されるサーバーレス関数
 - **Supabaseでの実装**: Deno Runtime上で動作
 - **実用例**: 決済処理・メール送信・複雑な計算
-- **参照章**: [Chapter 4: Edge Functions活用]({{ site.baseurl }}/chapters/chapter04/index.html)
+- **参照章**: [Chapter 4: Edge Functions活用]({{ '/chapters/chapter04/' | relative_url }})
 
 ### F
 
@@ -125,14 +125,14 @@ title: "用語辞典"
 - **定義**: Python製の高性能Webフレームワーク
 - **Supabaseでの組み合わせ**: 独立APIサーバーパターン
 - **実用例**: 複雑なビジネスロジック・エンタープライズAPI
-- **参照章**: [Chapter 5: 独立APIサーバー]({{ site.baseurl }}/chapter05-1.md)
+- **参照章**: [Chapter 5: 独立APIサーバー]({{ '/chapter05-1.html' | relative_url }})
 
 #### **Flet**
 `#framework` `#python` `#ui`
 - **定義**: PythonでネイティブUIアプリを作るフレームワーク
 - **Supabaseでの組み合わせ**: クライアントサイドパターン
 - **実用例**: デスクトップアプリ・内部管理ツール
-- **参照章**: [Chapter 3: クライアントサイド実装]({{ site.baseurl }}/chapters/chapter03/index.html)
+- **参照章**: [Chapter 3: クライアントサイド実装]({{ '/chapters/chapter03/' | relative_url }})
 
 ### J
 
@@ -141,7 +141,7 @@ title: "用語辞典"
 - **定義**: 安全な情報交換のためのトークン形式
 - **Supabaseでの実装**: 認証トークン・セッション管理
 - **実用例**: ログイン状態の維持・API認証
-- **参照章**: [Chapter 2: JWT詳細]({{ site.baseurl }}/chapters/chapter02/index.html)
+- **参照章**: [Chapter 2: JWT詳細]({{ '/chapters/chapter02/' | relative_url }})
 
 ### K
 


### PR DESCRIPTION
内部リンクの表記ゆれ（.md/.html/index.html）を Liquid + pretty URL に統一。\n- ドキュメント単体(.md)参照は .html に\n- 章や目次は /path/ + relative_url を使用