### PR TITLE
fix(nav): align prev/next titles; remove empty navigation.yml

### DIFF
--- a/docs/_includes/page-navigation.html
+++ b/docs/_includes/page-navigation.html
@@ -10,6 +10,21 @@ Order resolution strategy (first match wins):
 {% assign navigation = site.data.navigation %}
 
 {%- comment -%}
+Detect if current page is the top page (root). For project Pages, the
+root is "/<repo>/"; we normalize by stripping site.baseurl. If root,
+we suppress rendering of bottom navigation to unify top-page behavior.
+{%- endcomment -%}
+{%- assign _baseurl = site.baseurl | default: '' -%}
+{%- assign _page_url_n = page.url -%}
+{%- if _baseurl and _baseurl != '' -%}
+  {%- assign _page_url_n = _page_url_n | remove_first: _baseurl -%}
+{%- endif -%}
+{%- assign _is_root = false -%}
+{%- if _page_url_n == '/' or _page_url_n == '' -%}
+  {%- assign _is_root = true -%}
+{%- endif -%}
+
+{%- comment -%}
 Build a flattened list from navigation data for title lookup, so we can
 display ToC titles even when order falls back to site.pages.
 {%- endcomment -%}
@@ -103,6 +118,7 @@ display ToC titles even when order falls back to site.pages.
   {%- endif -%}
 {%- endif -%}
 
+{% unless _is_root %}
 <nav class="book-navigation" aria-label="Chapter navigation">
   <div class="chapter-nav">
     {% if previous_item %}
@@ -165,6 +181,7 @@ display ToC titles even when order falls back to site.pages.
     {% endif %}
   </div>
 </nav>
+{% endunless %}
 
 <style>
 .book-navigation { margin: 2rem 0; padding: 1rem; border-top: 1px solid var(--color-border, #e5e7eb); }

--- a/docs/_includes/page-navigation.html
+++ b/docs/_includes/page-navigation.html
@@ -17,7 +17,9 @@ we suppress rendering of bottom navigation to unify top-page behavior.
 {%- assign _baseurl = site.baseurl | default: '' -%}
 {%- assign _page_url_n = page.url -%}
 {%- if _baseurl and _baseurl != '' -%}
-  {%- assign _page_url_n = _page_url_n | remove_first: _baseurl -%}
+  {%- if _page_url_n | slice: 0, _baseurl.size == _baseurl -%}
+    {%- assign _page_url_n = _page_url_n | slice: _baseurl.size, _page_url_n.size -%}
+  {%- endif -%}
 {%- endif -%}
 {%- assign _is_root = false -%}
 {%- if _page_url_n == '/' or _page_url_n == '' -%}


### PR DESCRIPTION
- Use latest canonical bottom navigation include (prefers page.title)\n- Remove empty docs/_data/navigation.yml to avoid overriding navigation.json or site.pages\n- No content changes; navigation display consistency only