### PR TITLE
docs: 目次一行要約と第1章の読み方ガイド追加

### DIFF
--- a/docs/chapters/chapter01/index.md
+++ b/docs/chapters/chapter01/index.md
@@ -131,6 +131,11 @@ flowchart TB
 - 🔐 **Supabase Auth**: ログイン・ログアウトを管理
 - 📄 **PostgreSQL**: 全てのデータを保存する倉庫
 
+> **ここから先の読み方の目安**
+>  
+> ここまでの内容で、🌱 初心者レベルとしては「Supabase の全体像」と「主なコンポーネントの役割」が分かっていれば十分です。  
+> 以降では PostgreSQL や Supabase の内部構成、拡張機能など、より深い技術的背景に踏み込んでいきます。🚀/💪 レベル向けの内容となるため、一度手を動かしてから戻って読む、必要になったときに参照する、といった読み方でも問題ありません。
+
 ## 📄 PostgreSQL：「データの倉庫」を詳しく見てみよう
 
 ### 🤔 そもそもデータベースって何？
@@ -197,6 +202,8 @@ SELECT name, default_version, installed_version
 FROM pg_available_extensions 
 WHERE name IN ('pg_graphql', 'pgsodium', 'pg_stat_statements');
 ```
+
+この例が伝えたいポイントは、「Supabase は標準的な PostgreSQL を土台にしつつ、`pg_graphql` や `pgsodium` などの拡張機能を組み合わせることで、REST／GraphQL／暗号化／監視といった機能を一体として提供している」という点です。実際に SQL を実行する際は、必ず検証環境や Supabase の SQL エディタを用い、十分な権限を持つユーザーで実行してください。
 
 ## 🔗 PostgREST：「API自動生成の魔法」
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,18 +14,18 @@ permalink: /
 ## 目次
 
 - [はじめに]({{ site.baseurl }}/introduction/)
-- [第1章: Supabaseプロジェクトの基本セットアップ]({{ site.baseurl }}/chapters/chapter01/)
-- [第2章: Flet UIクライアントの基本実装]({{ site.baseurl }}/chapters/chapter02/)
-- [第3章: FastAPIサーバーの設計と実装]({{ site.baseurl }}/chapters/chapter03/)
-- [第4章: 3層構成での通信とデータフロー]({{ site.baseurl }}/chapters/chapter04/)
-- [第5章: 実装編その1: ユーザー管理システム]({{ site.baseurl }}/chapters/chapter05-1/)
-- [第5章: 実装編その2: ストライプ決済との統合]({{ site.baseurl }}/chapters/chapter05-2/)
-- [第5章: 実装編その3: リアルタイム通知システム]({{ site.baseurl }}/chapters/chapter05-3/)
-- [第6章: モニタリングとロギング]({{ site.baseurl }}/chapters/chapter06/)
-- [第7章: スケーリングとパフォーマンス最適化]({{ site.baseurl }}/chapters/chapter07/)
-- [第8章: セキュリティベストプラクティス]({{ site.baseurl }}/chapters/chapter08/)
-- [第9章: エンタープライズアーキテクチャパターン]({{ site.baseurl }}/chapters/chapter09/)
-- [第10章: 実運用とトラブルシューティング]({{ site.baseurl }}/chapters/chapter10/)
+- [第1章: Supabaseプロジェクトの基本セットアップ]({{ site.baseurl }}/chapters/chapter01/) — Supabase 全体像と開発環境構築
+- [第2章: Flet UIクライアントの基本実装]({{ site.baseurl }}/chapters/chapter02/) — クライアントサイドでの基本連携
+- [第3章: FastAPIサーバーの設計と実装]({{ site.baseurl }}/chapters/chapter03/) — バックエンドAPIサーバーの設計と実装
+- [第4章: 3層構成での通信とデータフロー]({{ site.baseurl }}/chapters/chapter04/) — クライアント・サーバー・DB間のデータフロー整理
+- [第5章: 実装編その1: ユーザー管理システム]({{ site.baseurl }}/chapters/chapter05-1/) — 認証・権限管理を含むユーザー管理パターン
+- [第5章: 実装編その2: ストライプ決済との統合]({{ site.baseurl }}/chapters/chapter05-2/) — 決済連携を伴うサブシステム統合パターン
+- [第5章: 実装編その3: リアルタイム通知システム]({{ site.baseurl }}/chapters/chapter05-3/) — Realtime を用いた通知・更新パターン
+- [第6章: モニタリングとロギング]({{ site.baseurl }}/chapters/chapter06/) — 運用監視とログ設計の基本
+- [第7章: スケーリングとパフォーマンス最適化]({{ site.baseurl }}/chapters/chapter07/) — 負荷増大に対応するスケーリング戦略
+- [第8章: セキュリティベストプラクティス]({{ site.baseurl }}/chapters/chapter08/) — Supabase を用いた実践的セキュリティ対策
+- [第9章: エンタープライズアーキテクチャパターン]({{ site.baseurl }}/chapters/chapter09/) — 大規模・複数プロジェクト向け構成
+- [第10章: 実運用とトラブルシューティング]({{ site.baseurl }}/chapters/chapter10/) — 障害対応・運用課題への対処パターン
 
 ## ガイド
 


### PR DESCRIPTION
## 概要

『Supabaseアーキテクチャパターン実践技術書』に対するレビュー結果を踏まえ、特にトップページと第1章において、章ごとの役割の一行要約と、第1章内のレベル別読み方ガイド／SQL例の位置づけを明示するための軽微な修正を行いました。内容や構成そのものには手を入れず、学習動線と安全な実行のための補助情報を追加しています。

## 変更内容

- 
  - 目次の各章リンクに、一行の補足説明を追加
    - 第1章: Supabase 全体像と開発環境構築
    - 第2章: Flet UI クライアントによる基本連携
    - 第3章: FastAPI バックエンド設計・実装
    - 第4章: クライアント・サーバー・DB 間のデータフロー整理
    - 第5章: ユーザー管理／決済統合／リアルタイム通知といった実装パターンの概要
    - 第6〜10章: 監視・スケーリング・セキュリティ・エンタープライズ構成・運用トラブル対応という位置づけを簡潔に一文で明示
  - これにより、一覧を眺めるだけでも各章がどのような役割・パターンを扱っているかが分かりやすくなるように調整

- 
  - Supabase 内部構成を説明する mermaid 図とコンポーネント役割一覧の直後に、「ここから先の読み方の目安」を追加
    - ここまでの内容で、🌱 初心者レベルとしては Supabase の全体像と主要コンポーネントの役割が分かっていれば十分であること
    - 以降の PostgreSQL や Supabase 拡張の説明は 🚀/💪 レベル向けの深掘りであり、一度手を動かしてから戻って読む・必要になったときに参照する読み方でもよいこと
  - Supabase 固有拡張（ /  / ）の SQL 例の直後に、要点と注意書きを追加
    - 要点として、「Supabase は標準 PostgreSQL を土台にしつつ、 や  等の拡張を組み合わせて REST／GraphQL／暗号化／監視といった機能を一体として提供している」ことを文章で明示
    - SQL を実行する際は、必ず検証環境や Supabase の SQL エディタを用い、十分な権限を持つユーザーで行うべきであることを注意書きとして追加

## 目的

- トップページ（）の目次からでも各章の役割と位置づけが一目で分かるようにし、学習者が自分に必要な章を選びやすくすること
- 第1章において、🌱/🚀/💪 のレベルアイコンと連動した「ここまでが基礎」「ここから先は応用・発展」の境界を簡単に示し、初心者が情報過多で挫折しにくくすること
- PostgreSQL／拡張機能に関する SQL 実行例について、「何を理解してほしいのか」と「どのような環境・権限で実行すべきか」を明示し、誤用や本番環境への不用意な実行リスクを下げること

これらの修正はスタイルや説明の補助にとどまり、既存の章構成や技術内容への影響は最小限です。