### PR TITLE
docs: README入口化 + ライセンス表記の整合

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,207 +1,30 @@
-# 📚 Book Publishing Template v2.0 - 改善版
+# Supabaseアーキテクチャパターン実践技術書
 
-> **大幅に使いやすくなった書籍出版テンプレート**
+スケーラブルな3層構成の設計と実装 - 初心者から上級者まで段階的に学べる、Supabase完全マスターガイド
 
-## 🎯 改善ポイント
+## オンライン版（推奨）
 
-### 1. **ワンコマンドセットアップ** 🚀
-```bash
-node easy-setup.js
-```
-- 対話式で簡単
-- 自動で設定ファイル生成
-- 日本語メッセージ
+- https://itdojp.github.io/supabase-architecture-patterns-book/
 
-### 2. **軽量ビルドシステム** ⚡
-```bash
-node scripts/build-simple.js
-```
-- 依存関係エラーなし
-- 高速ビルド
-- 分かりやすいエラー
+## この本について
 
-### 3. **最小限の依存関係** 📦
-```json
-// package-simple.json
-{
-  "dependencies": {
-    "fs-extra": "^11.1.0",
-    "gray-matter": "^4.0.3"
-  }
-}
-```
+Supabase を題材に、UI クライアント / API サーバー / BaaS（Supabase）を分離した「3層構成」の設計と実装パターンを、段階的に学ぶことを目的とした技術書です。
 
-### 4. **5分で始められる** ⏱️
-- [QUICK-START.md](QUICK-START.md) - 超簡単ガイド
-- 複雑な設定不要
-- すぐに執筆開始
+## まず読む場所
 
-### 5. **GitHub Pages自動設定** 🔧
-- GitHub Actionsワークフロー自動生成
-- 2つの設定方式に対応（Legacy/Actions）
-- 404エラー対策済み
+- はじめに: `docs/introduction/index.md`
+- 第1章: `docs/chapters/chapter01/index.md`
 
-## 📋 主な改善内容
+## 目次
 
-| 項目 | 改善前 | 改善後 |
-|------|--------|--------|
-| **初期設定** | 5段階の手動設定 | 1コマンド |
-| **エラーメッセージ** | 英語・技術的 | 日本語・分かりやすい |
-| **依存関係** | 重い・エラー多発 | 軽量・安定 |
-| **ビルド時間** | 遅い | 高速 |
-| **必要な知識** | 高度 | 基本的 |
-| **リポジトリ構成** | デュアル（複雑） | 単一（シンプル） |
-| **トークン設定** | 必須 | 不要 |
+- `docs/index.md`（オンライン版の目次ページと同内容）
 
-## 🚀 使い方
+## ライセンス
 
-### 1. セットアップ（1分）
-```bash
-git clone https://github.com/itdojp/book-publishing-template2.git my-book
-cd my-book
-node easy-setup.js
-```
+- `LICENSE.md`（Creative Commons BY-NC-SA 4.0 / シリーズ統一ライセンス準拠）
 
-### 2. 執筆
-```bash
-# src/chapters/chapter01/index.md を編集
-```
+## 執筆・ビルド（開発者向け）
 
-### 3. ビルド&プレビュー
-```bash
-npm run build
-npm run preview
-```
-
-### 4. GitHub Pages設定
-```bash
-git add -A
-git commit -m "Initial commit"
-git push
-
-# GitHubで: Settings > Pages > Source: main branch /docs folder
-```
-
-## 📁 シンプルな構造
-
-```
-my-book/
-├── src/               # 原稿
-│   ├── introduction/  # はじめに
-│   └── chapters/      # 各章
-├── docs/              # ビルド出力（GitHub Pages用）
-├── assets/           # 画像
-├── easy-setup.js     # セットアップツール
-└── book-config.json  # 設定ファイル
-```
-
-## 🔧 カスタマイズ
-
-必要に応じて高度な機能を追加：
-- `package.json` - フル機能版
-- `scripts/build.js` - 高度なビルド
-- プラグインシステム
-- テーマシステム
-
-## 📚 ドキュメント
-
-### 🚀 クイックスタート
-- [QUICK-START.md](QUICK-START.md) - 5分で始める
-- [TROUBLESHOOTING.md](TROUBLESHOOTING.md) - トラブルシューティング
-
-### 📖 詳細ガイド
-- [REPOSITORY-ACCESS-GUIDE.md](REPOSITORY-ACCESS-GUIDE.md) - リポジトリ構成とアクセス権
-- [MIGRATION-PLAN.md](MIGRATION-PLAN.md) - 既存版からの移行
-- [UPGRADE-GUIDE.md](UPGRADE-GUIDE.md) - アップグレードガイド
-- [COMPARISON.md](COMPARISON.md) - 既存版との比較
-
-### 🔧 技術ドキュメント
-- [Docs/](Docs/) - 詳細技術ドキュメント
-- [TECHNICAL-CONTEXT.md](TECHNICAL-CONTEXT.md) - 技術的背景
-- [FEEDBACK-COLLECTION.md](FEEDBACK-COLLECTION.md) - フィードバック収集計画
-
-## 🔧 GitHub Actions ワークフロー管理
-
-### 問題のあるワークフローを無効化
-
-テンプレートを使用する際、不要なワークフローが原因でActionsがハングアップすることがあります。
-
-```bash
-npm run configure:workflows
-```
-
-このコマンドで以下のワークフローを自動無効化します：
-- `content-validation.yml` (リンクチェックでハングアップ)
-- `quality-checks.yml` (長時間実行)
-- `build-with-cache.yml` (重複ビルド)
-- `parallel-build-test.yml` (テスト用)
-- `validate-secrets.yml` (設定複雑)
-
-### 推奨ワークフロー構成
-
-本番環境では`build.yml`のみを有効にすることを推奨します：
-- GitHub Pagesへの自動デプロイ
-- 最小限のビルド時間
-- エラーが少ない安定動作
-
-## 🚨 Jekyll Liquid構文競合対策
-
-### 問題の説明
-
-Podmanやコンテナ関連の技術書では、以下のような構文がJekyll Liquidテンプレートと競合することがあります：
-
-```markdown
-# 問題となる構文例
-{{.Container}}          # Podmanフォーマット文字列
-{{app="myapp"}}         # Prometheus クエリ
-{{$labels.name}}        # アラート設定
-```
-
-### 自動検出・修正ツール
-
-```bash
-# 競合をチェック
-npm run check-conflicts
-
-# 自動修正
-npm run fix-conflicts
-
-# 競合対策付きビルド
-npm run build:safe
-```
-
-### 手動修正方法
-
-Jekyll Liquidと競合する `{{}}` を `\{\{\}\}` にエスケープ：
-
-```markdown
-# 修正前
-query = 'rate(http_requests_total{{app="myapp"}}[5m])'
-
-# 修正後  
-query = 'rate(http_requests_total\{\{app="myapp"\}\}[5m])'
-```
-
-### 対策が自動適用されるパターン
-
-- Container Format Strings: `{{.Container}}`, `{{.Names}}`
-- Prometheus Queries: `{{app="..."}}`
-- Template Variables: `{{variable}}`
-- Kubernetes Templates: `{{template "..."}}`
-
-## 🤝 サポート
-
-- Issues: https://github.com/itdojp/book-publishing-template2/issues
-- 元のテンプレート: https://github.com/itdojp/book-publishing-template
-
-## ✨ 特徴
-
-- ✅ **初心者に優しい**: 技術的な知識不要
-- ✅ **高速**: 軽量で高速なビルド
-- ✅ **柔軟**: 必要に応じて拡張可能
-- ✅ **安定**: エラーが少ない
-- ✅ **日本語対応**: メッセージが分かりやすい
-
----
-
-**Happy Writing! 📖✨**
+- クイックスタート: `QUICK-START.md`
+- GitHub Pages: `GITHUB-PAGES-SETUP.md`
+- 移行/運用: `MIGRATION-PLAN.md` / `UPGRADE-GUIDE.md`

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,9 +46,20 @@ permalink: /
 - Email: [knowledge@itdo.jp](mailto:knowledge@itdo.jp)
 - GitHub: [@itdojp](https://github.com/itdojp)
 
-## ライセンス
+## 📄 ライセンス
 
-© 2025 株式会社アイティードゥ. All rights reserved.
+本書は **Creative Commons BY-NC-SA 4.0** ライセンスで公開されています。  
+**🔓 教育・研究・個人学習での利用は自由** ですが、**💼 商用利用には事前許諾** が必要です。
+
+📋 [詳細なライセンス条件](https://github.com/itdojp/it-engineer-knowledge-architecture/blob/main/LICENSE.md)
+
+**お問い合わせ**  
+株式会社アイティードゥ（ITDO Inc.）  
+Email: [knowledge@itdo.jp](mailto:knowledge@itdo.jp)
+
+---
+
+© 2025 株式会社アイティードゥ (ITDO Inc.)
 
 ---
 

--- a/docs/introduction/index.md
+++ b/docs/introduction/index.md
@@ -7,7 +7,6 @@ title: "本書について"
 
 **初心者から上級者まで段階的に学べる、Supabase完全マスターガイド**
 
-![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)
 ![Version: 1.0](https://img.shields.io/badge/Version-1.0-brightgreen.svg)
 ![Status: Active Development](https://img.shields.io/badge/Status-Active%20Development-green.svg)
 
@@ -309,7 +308,8 @@ src/
 
 ## 📄 ライセンス・サポート
 
-**ライセンス**: MIT License  
+**ライセンス**: Creative Commons BY-NC-SA 4.0  
+**ライセンス（詳細）**: https://github.com/itdojp/it-engineer-knowledge-architecture/blob/main/LICENSE.md  
 **著者**: 株式会社アイティードゥ  
 **サポート**: [GitHub Issues](https://github.com/itdojp/supabase-architecture-patterns-book/issues) にて対応  
 
@@ -319,4 +319,4 @@ src/
 
 **📖 今すぐ学習開始**: [Chapter 1: Supabase基礎知識]({{ '/chapters/chapter01/' | relative_url }})  
 **💬 質問・相談**: [GitHub Discussions](https://github.com/itdojp/supabase-architecture-patterns-book/discussions)  
-**📧 フィードバック**: [お問い合わせ](mailto:contact@itdo.jp)
+**📧 フィードバック**: [お問い合わせ](mailto:knowledge@itdo.jp)


### PR DESCRIPTION
GitHub リポジトリのトップ（README）を「読者・学習者の入口」として整備し、ライセンス表記の不整合を解消しました。

- `README.md`: 書籍の入口（オンライン版リンク / 読み始めの案内 / 目次参照 / ライセンス参照）へ置き換え
- `docs/index.md`: ライセンス表記を `LICENSE.md`（CC BY-NC-SA 4.0 / シリーズ統一ライセンス）と整合
- `docs/introduction/index.md`: MIT 表記を削除し、同ライセンスへ整合（連絡先も `knowledge@itdo.jp` に統一）

※ 本PRは入口/ライセンス表記の整合のみで、章本文の内容編集は行っていません。
