### PR TITLE
fix: 付録Aのtitleを見出しに整合

### DIFF
--- a/docs/appendices/appendix-a/index.md
+++ b/docs/appendices/appendix-a/index.md
@@ -1,7 +1,7 @@
 ---
 layout: book
 order: 20
-title: "付録A: 追加リソース"
+title: "付録A: 設定リファレンス"
 ---
 # 付録A: 設定リファレンス
 


### PR DESCRIPTION
付録A（`docs/appendices/appendix-a/index.md`）で front matter の `title` とH1が不一致だったため、H1（`付録A: 設定リファレンス`）に合わせて整合しました。\n\n- 変更はメタ情報のみで、本文の意味変更はありません。