### PR TITLE
fix(stage2): 第2章のtitleをH1に整合

### DIFF
--- a/docs/chapters/chapter02/index.md
+++ b/docs/chapters/chapter02/index.md
@@ -1,7 +1,7 @@
 ---
 layout: book
 order: 4
-title: "第2章：認証・認可設計"
+title: "Chapter 2: 認証・認可設計 🔐"
 ---
 # Chapter 2: 認証・認可設計 🔐
 


### PR DESCRIPTION
`docs/chapters/chapter02/index.md` で front matter の `title` とH1が不一致だったため、H1（`Chapter 2: 認証・認可設計 🔐`）に合わせて `title` を整合しました。\n\n- 変更はメタ情報のみで、本文の意味変更はありません。\n- 当該ファイルはCRLFのため、改行コードを維持したまま1行のみ更新しています。