### PR TITLE
fix(stage2): 学習ガイドのtitleをH1に整合

### DIFF
--- a/docs/introduction/index.md
+++ b/docs/introduction/index.md
@@ -1,7 +1,7 @@
 ---
 layout: book
 order: 2
-title: "本書について"
+title: "🏗️ Supabaseアーキテクチャパターン実践技術書 - 学習ガイド"
 ---
 # 🏗️ Supabaseアーキテクチャパターン実践技術書 - 学習ガイド
 


### PR DESCRIPTION
`docs/introduction/index.md` で front matter の `title` とH1が不一致だったため、H1（`🏗️ Supabaseアーキテクチャパターン実践技術書 - 学習ガイド`）に合わせて `title` を整合しました。\n\n- 変更はメタ情報のみで、本文の意味変更はありません。\n- 当該ファイルはCRLFのため、改行コードを維持したまま1行のみ更新しています。