### PR TITLE
chore(ci): add layout risk scan to Book QA

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -1,4 +1,4 @@
-name: Book QA (Unicode + Links + Textlint)
+name: Book QA (Unicode + Links + Textlint + Layout Risk)
 
 on:
   pull_request:
@@ -51,18 +51,17 @@ jobs:
 
       - name: Link check (internal + anchors)
         run: node book-formatter/scripts/check-links.js "${{ steps.scan.outputs.dir }}"
+
       - name: Layout risk scan (long lines / tables / images)
-        run: node book-formatter/scripts/check-layout-risk.js "${{ steps.scan.outputs.dir }}" --fail-on error --output layout-risk-report.json
+        run: node book-formatter/scripts/check-layout-risk.js "${{ steps.scan.outputs.dir }}" --fail-on error --output "${{ runner.temp }}/layout-risk-report.json"
 
       - name: Upload layout risk report
-        if: ${{ always() && hashFiles('layout-risk-report.json') != '' }}
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: layout-risk-report
-          path: layout-risk-report.json
-
-
-
+          path: ${{ runner.temp }}/layout-risk-report.json
+          if-no-files-found: ignore
       - name: Build (Jekyll; GitHub Pages compatible)
         uses: actions/jekyll-build-pages@v1
         with:

--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: itdojp/book-formatter
-          ref: b4719a526043ee27554bc59ca18e4fec1d709812
+          ref: a46df0a21ef5ab57442e8aac835dc44f06058fb2
           path: book-formatter
 
       - name: Setup Node.js
@@ -51,6 +51,16 @@ jobs:
 
       - name: Link check (internal + anchors)
         run: node book-formatter/scripts/check-links.js "${{ steps.scan.outputs.dir }}"
+      - name: Layout risk scan (long lines / tables / images)
+        run: node book-formatter/scripts/check-layout-risk.js "${{ steps.scan.outputs.dir }}" --fail-on error --output layout-risk-report.json
+
+      - name: Upload layout risk report
+        if: ${{ always() && hashFiles('layout-risk-report.json') != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: layout-risk-report
+          path: layout-risk-report.json
+
 
 
       - name: Build (Jekyll; GitHub Pages compatible)


### PR DESCRIPTION
Issue: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102

変更点
- Book QA に layout risk scan（長い行/ワイドな表/画像）を追加
- layout-risk-report.json を artifact としてアップロード
- book-formatter の checkout ref を固定（a46df0a21ef5ab57442e8aac835dc44f06058fb2）
