### PR TITLE
chore(ci): bump book-formatter pin

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: itdojp/book-formatter
-          ref: a46df0a21ef5ab57442e8aac835dc44f06058fb2
+          ref: 0388ced8d757687c56697439e4bcf07062df5026
           path: book-formatter
 
       - name: Setup Node.js


### PR DESCRIPTION
book-formatter の pin（Book QA で checkout する ref）を更新します。

- 変更: `a46df0a` -> `0388ced`
- 目的: layout risk scan の誤検知低減（book-formatter#72）を全書籍へ反映

注: 参照先は commit SHA を pin し、チェックの再現性は維持します。