### PR TITLE
fix(layout): wrap long className

### DIFF
--- a/docs/guides/error-handling/index.md
+++ b/docs/guides/error-handling/index.md
@@ -1135,7 +1135,11 @@ export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({
           {error.recoverable && onRetry && (
             <button
               onClick={onRetry}
-              className="inline-flex items-center px-3 py-1 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 mr-2"
+              className={`
+                inline-flex items-center px-3 py-1 border border-transparent text-sm font-medium rounded-md
+                text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2
+                focus:ring-blue-500 mr-2
+              `}
             >
               再試行
             </button>
@@ -1144,7 +1148,11 @@ export const ErrorDisplay: React.FC<ErrorDisplayProps> = ({
           {onDismiss && (
             <button
               onClick={onDismiss}
-              className="inline-flex items-center px-3 py-1 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 mr-2"
+              className={`
+                inline-flex items-center px-3 py-1 border border-gray-300 text-sm font-medium rounded-md
+                text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2
+                focus:ring-blue-500 mr-2
+              `}
             >
               閉じる
             </button>


### PR DESCRIPTION
layout risk scan（maxCodeLineLength=200）の警告（long_code_line）を低減するため、JSX例の `className` を複数行（テンプレートリテラル）に整形しました。

- 対象: `docs/guides/error-handling/index.md`
- 変更方針: 意味を変えずに改行（class属性の空白はTailwindの区切りとして解釈されるため挙動は同等）
- 確認: `book-formatter/scripts/check-layout-risk.js` で issues=0（warnings=0）

Issue: itdojp/it-engineer-knowledge-architecture#102
