### PR TITLE
chore(ci): bump book-formatter pin

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: itdojp/book-formatter
-          ref: 6b54a2abed0e2e8bbd8966bafddf0dd06131e114
+          ref: b7e85c4af4f4c5580b00fc103c2a6603acdb0798
           path: book-formatter
 
       - name: Setup Node.js


### PR DESCRIPTION
book-formatter の pin（Book QA で checkout する ref）を更新します。

- 変更: `6b54a2a` -> `b7e85c4`
- 目的: EOL 環境例（Ubuntu 20.04 / Amazon Linux 2）の再混入を検出し、CI でブロックできるようにする（book-formatter#74）

注: 参照先は commit SHA を pin し、チェックの再現性は維持します。