### PR TITLE
fix(docs): update Node.js prerequisite

### DIFF
--- a/.github/ISSUE_TEMPLATE/setup-issue.yml
+++ b/.github/ISSUE_TEMPLATE/setup-issue.yml
@@ -80,7 +80,7 @@ body:
       label: Pre-requirements check / 前提条件チェック
       description: Please confirm you have checked these
       options:
-        - label: I have Node.js 18+ installed / Node.js 18以上がインストール済み
+        - label: I have Node.js 20+ installed / Node.js 20以上がインストール済み
           required: true
         - label: I have git installed / gitがインストール済み
           required: true

--- a/HANDOVER-SUMMARY.md
+++ b/HANDOVER-SUMMARY.md
@@ -53,7 +53,7 @@ https://github.com/itdojp/book-publishing-template
 }
 
 // 開発環境
-Node.js 18+, GitHub CLI認証済み
+Node.js 20+, GitHub CLI認証済み
 権限: itdojp organization maintain
 ```
 

--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -169,7 +169,7 @@ v2.0テンプレートの使用を強く推奨します
 ### 前提条件
 ```bash
 # 必要なツール
-- Node.js 18+
+- Node.js 20+
 - Git
 - GitHub CLI (gh)
 - 適切なGitHub権限（itdojp organizationのmaintain権限）
@@ -238,7 +238,7 @@ gh pr create --title "Add new feature" --body "Description"
 #### 1. セットアップエラー
 ```bash
 # 症状: easy-setup.js実行時のエラー
-# 解決: Node.js 18以上の確認、権限確認
+# 解決: Node.js 20以上の確認、権限確認
 
 # デバッグコマンド
 node --version

--- a/QUICK-START.md
+++ b/QUICK-START.md
@@ -14,7 +14,7 @@ cd my-book
 ### Step 2: 自動セットアップ実行
 
 ```bash
-# Node.js 18以上が必要
+# Node.js 20以上が必要
 node easy-setup.js
 ```
 

--- a/docs/introduction/index.md
+++ b/docs/introduction/index.md
@@ -283,7 +283,7 @@ src/
 各サンプルは以下で動作確認済み：
 - ✅ Supabase v2.39.0
 - ✅ Python 3.11+
-- ✅ Node.js 18+
+- ✅ Node.js 20+
 - ✅ Docker Compose v2.0+
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "markdownlint-cli": "^0.33.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "optionalDependencies": {
         "puppeteer": "^21.0.0",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "ITDO Inc.（株式会社アイティードゥ）",
   "license": "CC-BY-NC-SA-4.0",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "start": "jekyll serve --livereload",

--- a/src/introduction/index.md
+++ b/src/introduction/index.md
@@ -279,7 +279,7 @@ src/
 各サンプルは以下で動作確認済み：
 - ✅ Supabase v2.39.0
 - ✅ Python 3.11+
-- ✅ Node.js 18+
+- ✅ Node.js 20+
 - ✅ Docker Compose v2.0+
 
 ---

--- a/templates/github-workflows/build-actions.yml
+++ b/templates/github-workflows/build-actions.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
         cache: 'npm'
         
     - name: Install dependencies

--- a/templates/github-workflows/build-legacy.yml
+++ b/templates/github-workflows/build-legacy.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
         cache: 'npm'
         
     - name: Install dependencies


### PR DESCRIPTION
## 変更内容
- Node.js 前提の記載を更新
  - Node.js 18+ / 18以上 → 20+ / 20以上（QUICK-START/HANDOVER/Introduction）

## 背景
- Node.js 18 はサポート終了（EOL）のため、前提条件の記載を更新します。

## 影響範囲
- ドキュメントのみ（本文ロジック/ビルド設定/CI 変更なし）
