### PR TITLE
docker-compose を docker compose (Compose v2) に移行

### DIFF
--- a/docs/appendices/appendix01/index.md
+++ b/docs/appendices/appendix01/index.md
@@ -55,13 +55,19 @@ echo "プロジェクト名: $PROJECT_NAME"
 
 # 必要なツールのチェック
 check_dependencies() {
-    local deps=("docker" "docker-compose" "psql" "curl" "jq")
+    local deps=("docker" "psql" "curl" "jq" "openssl")
     for dep in "${deps[@]}"; do
         if ! command -v "$dep" &> /dev/null; then
             echo "❌ $dep がインストールされていません"
             exit 1
         fi
     done
+
+    # Compose v2（docker compose）前提。Compose v1（docker-compose）は前提にしない。
+    if ! docker compose version &> /dev/null; then
+        echo "❌ Docker Compose（Compose v2）が利用できません（'docker compose version' が失敗しました）"
+        exit 1
+    fi
     echo "✅ 依存関係チェック完了"
 }
 
@@ -525,7 +531,7 @@ create_dev_scripts() {
     cat > scripts/start.sh << 'EOF'
 #!/bin/bash
 echo "🚀 Supabase開発環境起動中..."
-docker-compose up -d
+docker compose up -d
 
 echo "⏳ サービス起動待機中..."
 sleep 10
@@ -546,7 +552,7 @@ EOF
     cat > scripts/stop.sh << 'EOF'
 #!/bin/bash
 echo "🛑 Supabase開発環境停止中..."
-docker-compose down
+docker compose down
 echo "✅ 停止完了"
 EOF
 
@@ -554,8 +560,8 @@ EOF
     cat > scripts/reset.sh << 'EOF'
 #!/bin/bash
 echo "🔄 Supabase開発環境リセット中..."
-docker-compose down -v
-docker-compose up -d
+docker compose down -v
+docker compose up -d
 echo "✅ リセット完了"
 EOF
 
@@ -566,7 +572,7 @@ BACKUP_DIR="backups/$(date +%Y%m%d_%H%M%S)"
 mkdir -p "$BACKUP_DIR"
 
 echo "💾 データベースバックアップ中..."
-docker-compose exec -T supabase-db pg_dump -U postgres -d postgres > "$BACKUP_DIR/database.sql"
+docker compose exec -T supabase-db pg_dump -U postgres -d postgres > "$BACKUP_DIR/database.sql"
 
 echo "📁 設定ファイルバックアップ中..."
 cp -r supabase/migrations "$BACKUP_DIR/"

--- a/docs/chapters/chapter01/index.md
+++ b/docs/chapters/chapter01/index.md
@@ -753,17 +753,17 @@ fi
 
 # Docker環境起動
 echo "🐳 Docker Compose起動"
-docker-compose up -d
+docker compose up -d
 
 # データベース接続待機
 echo "⏳ PostgreSQL起動待機"
-until docker-compose exec supabase-db pg_isready; do
+until docker compose exec supabase-db pg_isready; do
     sleep 2
 done
 
 # マイグレーション実行
 echo "📊 初期スキーマ作成"
-docker-compose exec supabase-db psql -U postgres -d postgres -f /docker-entrypoint-initdb.d/001_initial_schema.sql
+docker compose exec supabase-db psql -U postgres -d postgres -f /docker-entrypoint-initdb.d/001_initial_schema.sql
 
 echo "✅ セットアップ完了"
 echo "🌐 Supabase Studio: http://localhost:3000"
@@ -921,16 +921,16 @@ SELECT * FROM your_table_name;
 **チェックリスト**:
 ```bash
 # 1. ログ確認
-docker-compose logs supabase-db
-docker-compose logs supabase-auth
+docker compose logs supabase-db
+docker compose logs supabase-auth
 
 # 2. ポート競合確認
 sudo lsof -i :54321
 sudo lsof -i :54322
 
 # 3. 環境リセット
-docker-compose down -v
-docker-compose up -d
+docker compose down -v
+docker compose up -d
 
 # 4. ヘルスチェック
 curl http://localhost:54321/rest/v1/

--- a/docs/chapters/chapter05-1/index.md
+++ b/docs/chapters/chapter05-1/index.md
@@ -1144,8 +1144,8 @@ cp backend/.env.example backend/.env
 # Docker でRedis起動
 docker run -d --name redis-saas -p 6379:6379 redis:7-alpine
 
-# または docker-compose 使用
-docker-compose up -d redis
+# または docker compose 使用
+docker compose up -d redis
 ```
 
 ### 📋 Step 4: アプリケーション起動

--- a/docs/chapters/chapter08/index.md
+++ b/docs/chapters/chapter08/index.md
@@ -1401,7 +1401,7 @@ class AlertManager:
       
       - name: Start test environment
         run: |
-          docker-compose -f docker-compose.test.yml up -d
+          docker compose -f docker-compose.test.yml up -d
           sleep 30  # アプリケーション起動待機
       
       - name: Run load tests

--- a/src/appendices/appendix01/index.md
+++ b/src/appendices/appendix01/index.md
@@ -50,13 +50,19 @@ echo "プロジェクト名: $PROJECT_NAME"
 
 # 必要なツールのチェック
 check_dependencies() {
-    local deps=("docker" "docker-compose" "psql" "curl" "jq")
+    local deps=("docker" "psql" "curl" "jq" "openssl")
     for dep in "${deps[@]}"; do
         if ! command -v "$dep" &> /dev/null; then
             echo "❌ $dep がインストールされていません"
             exit 1
         fi
     done
+
+    # Compose v2（docker compose）前提。Compose v1（docker-compose）は前提にしない。
+    if ! docker compose version &> /dev/null; then
+        echo "❌ Docker Compose（Compose v2）が利用できません（'docker compose version' が失敗しました）"
+        exit 1
+    fi
     echo "✅ 依存関係チェック完了"
 }
 
@@ -520,7 +526,7 @@ create_dev_scripts() {
     cat > scripts/start.sh << 'EOF'
 #!/bin/bash
 echo "🚀 Supabase開発環境起動中..."
-docker-compose up -d
+docker compose up -d
 
 echo "⏳ サービス起動待機中..."
 sleep 10
@@ -541,7 +547,7 @@ EOF
     cat > scripts/stop.sh << 'EOF'
 #!/bin/bash
 echo "🛑 Supabase開発環境停止中..."
-docker-compose down
+docker compose down
 echo "✅ 停止完了"
 EOF
 
@@ -549,8 +555,8 @@ EOF
     cat > scripts/reset.sh << 'EOF'
 #!/bin/bash
 echo "🔄 Supabase開発環境リセット中..."
-docker-compose down -v
-docker-compose up -d
+docker compose down -v
+docker compose up -d
 echo "✅ リセット完了"
 EOF
 
@@ -561,7 +567,7 @@ BACKUP_DIR="backups/$(date +%Y%m%d_%H%M%S)"
 mkdir -p "$BACKUP_DIR"
 
 echo "💾 データベースバックアップ中..."
-docker-compose exec -T supabase-db pg_dump -U postgres -d postgres > "$BACKUP_DIR/database.sql"
+docker compose exec -T supabase-db pg_dump -U postgres -d postgres > "$BACKUP_DIR/database.sql"
 
 echo "📁 設定ファイルバックアップ中..."
 cp -r supabase/migrations "$BACKUP_DIR/"

--- a/src/chapters/chapter01/index.md
+++ b/src/chapters/chapter01/index.md
@@ -1253,17 +1253,17 @@ fi
 
 # Docker環境起動
 echo "🐳 Docker Compose起動"
-docker-compose up -d
+docker compose up -d
 
 # データベース接続待機
 echo "⏳ PostgreSQL起動待機"
-until docker-compose exec supabase-db pg_isready; do
+until docker compose exec supabase-db pg_isready; do
     sleep 2
 done
 
 # マイグレーション実行
 echo "📊 初期スキーマ作成"
-docker-compose exec supabase-db psql -U postgres -d postgres -f /docker-entrypoint-initdb.d/001_initial_schema.sql
+docker compose exec supabase-db psql -U postgres -d postgres -f /docker-entrypoint-initdb.d/001_initial_schema.sql
 
 echo "✅ セットアップ完了"
 echo "🌐 Supabase Studio: http://localhost:3000"
@@ -1421,16 +1421,16 @@ SELECT * FROM your_table_name;
 **チェックリスト**:
 ```bash
 # 1. ログ確認
-docker-compose logs supabase-db
-docker-compose logs supabase-auth
+docker compose logs supabase-db
+docker compose logs supabase-auth
 
 # 2. ポート競合確認
 sudo lsof -i :54321
 sudo lsof -i :54322
 
 # 3. 環境リセット
-docker-compose down -v
-docker-compose up -d
+docker compose down -v
+docker compose up -d
 
 # 4. ヘルスチェック
 curl http://localhost:54321/rest/v1/

--- a/src/chapters/chapter05-1/index.md
+++ b/src/chapters/chapter05-1/index.md
@@ -1139,8 +1139,8 @@ cp backend/.env.example backend/.env
 # Docker でRedis起動
 docker run -d --name redis-saas -p 6379:6379 redis:7-alpine
 
-# または docker-compose 使用
-docker-compose up -d redis
+# または docker compose 使用
+docker compose up -d redis
 ```
 
 ### 📋 Step 4: アプリケーション起動

--- a/src/chapters/chapter08/index.md
+++ b/src/chapters/chapter08/index.md
@@ -1395,7 +1395,7 @@ class AlertManager:
       
       - name: Start test environment
         run: |
-          docker-compose -f docker-compose.test.yml up -d
+          docker compose -f docker-compose.test.yml up -d
           sleep 30  # アプリケーション起動待機
       
       - name: Run load tests


### PR DESCRIPTION
- コマンド例を `docker compose`（Compose v2）に統一しました（`docker-compose.yml` 等のファイル名は維持）。\n- 付録のセットアップスクリプトは `docker compose version` でCompose利用可否を判定するよう更新しました。\n