### PR TITLE
CI記述例の GitHub Actions バージョンを v4 に更新

### DIFF
--- a/docs/chapters/chapter05-3/index.md
+++ b/docs/chapters/chapter05-3/index.md
@@ -1283,7 +1283,7 @@ jobs:
     
     steps:
     - name: 📥 コードチェックアウト
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     
     - name: 🐍 Python環境セットアップ
       uses: actions/setup-python@v4
@@ -1355,7 +1355,7 @@ jobs:
     
     steps:
     - name: 📥 コードチェックアウト
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     
     - name: 🔧 Docker Buildx セットアップ
       uses: docker/setup-buildx-action@v2
@@ -1478,7 +1478,7 @@ jobs:
     
     steps:
     - name: 📥 コードチェックアウト
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     
     - name: 🐍 Python環境セットアップ
       uses: actions/setup-python@v4
@@ -2696,7 +2696,7 @@ jobs:
           - 6379:6379
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Set up Python
       uses: actions/setup-python@v4
@@ -2738,7 +2738,7 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Run security scan
       run: |
@@ -2752,7 +2752,7 @@ jobs:
     if: github.event_name == 'push'
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2

--- a/docs/chapters/chapter10/index.md
+++ b/docs/chapters/chapter10/index.md
@@ -1591,7 +1591,7 @@ jobs:
           --health-retries 5
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Setup Python
       uses: actions/setup-python@v4
@@ -1634,7 +1634,7 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Run security scan
       run: |
@@ -1651,7 +1651,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Log in to Container Registry
       uses: docker/login-action@v2

--- a/src/chapters/chapter05-3/index.md
+++ b/src/chapters/chapter05-3/index.md
@@ -1278,7 +1278,7 @@ jobs:
     
     steps:
     - name: 📥 コードチェックアウト
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     
     - name: 🐍 Python環境セットアップ
       uses: actions/setup-python@v4
@@ -1350,7 +1350,7 @@ jobs:
     
     steps:
     - name: 📥 コードチェックアウト
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     
     - name: 🔧 Docker Buildx セットアップ
       uses: docker/setup-buildx-action@v2
@@ -1473,7 +1473,7 @@ jobs:
     
     steps:
     - name: 📥 コードチェックアウト
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     
     - name: 🐍 Python環境セットアップ
       uses: actions/setup-python@v4
@@ -2690,7 +2690,7 @@ jobs:
           - 6379:6379
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Set up Python
       uses: actions/setup-python@v4
@@ -2732,7 +2732,7 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Run security scan
       run: |
@@ -2746,7 +2746,7 @@ jobs:
     if: github.event_name == 'push'
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2

--- a/src/chapters/chapter10/index.md
+++ b/src/chapters/chapter10/index.md
@@ -1588,7 +1588,7 @@ jobs:
           --health-retries 5
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Setup Python
       uses: actions/setup-python@v4
@@ -1631,7 +1631,7 @@ jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Run security scan
       run: |
@@ -1648,7 +1648,7 @@ jobs:
     if: github.ref == 'refs/heads/main'
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     
     - name: Log in to Container Registry
       uses: docker/login-action@v2


### PR DESCRIPTION
Issue #102 の残作業（非推奨記述の棚卸し）対応です。

- 書籍本文の CI 記述例で `actions/checkout@v3` を `actions/checkout@v4` に更新
- `src` / `docs` の重複管理ファイルを同期更新
