### PR TITLE
Book QA に Markdown構造チェックを追加

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Upload markdown structure report
         if: always()
-        uses: actions/upload-artifact
+        uses: actions/upload-artifact@v4
         with:
           name: markdown-structure-report
           path: ${{ runner.temp }}/markdown-structure-report.json

--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: itdojp/book-formatter
-          ref: b7e85c4af4f4c5580b00fc103c2a6603acdb0798
+          ref: 2a0180954286b731cb0d91545aa77e9ee478570d
           path: book-formatter
 
       - name: Setup Node.js
@@ -54,6 +54,17 @@ jobs:
 
       - name: Layout risk scan (long lines / tables / images)
         run: node book-formatter/scripts/check-layout-risk.js "${{ steps.scan.outputs.dir }}" --fail-on error --output "${{ runner.temp }}/layout-risk-report.json"
+
+      - name: Markdown structure check (front matter / headings / fences)
+        run: node book-formatter/scripts/check-markdown-structure.js "${{ steps.scan.outputs.dir }}" --fail-on error --output "${{ runner.temp }}/markdown-structure-report.json"
+
+      - name: Upload markdown structure report
+        if: always()
+        uses: actions/upload-artifact
+        with:
+          name: markdown-structure-report
+          path: ${{ runner.temp }}/markdown-structure-report.json
+          if-no-files-found: ignore
 
       - name: Upload layout risk report
         if: always()


### PR DESCRIPTION
## 概要
Book QA に Markdown 構造チェックを追加します。

- `check-markdown-structure` を追加（Front Matter / 見出しレベル / コードフェンス）
- レポートを artifact としてアップロード
- `book-formatter` pin を更新
  - `b7e85c4af4f4c5580b00fc103c2a6603acdb0798` -> `2a0180954286b731cb0d91545aa77e9ee478570d`

## 補足
- Fail条件は `--fail-on error` とし、warningは可視化運用
- 既存の Unicode / textlint / links / layout risk / Jekyll build / smoke check は維持
