### PR TITLE
CI記述例の公式GitHub Actions参照を更新

### DIFF
--- a/book-template-guide.md
+++ b/book-template-guide.md
@@ -91,7 +91,7 @@ jobs:
 
       # 出力先は書籍の構成に合わせて調整（例: Jekyllなら docs/_site）
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: ./docs/_site
 

--- a/docs/chapters/chapter05-3/index.md
+++ b/docs/chapters/chapter05-3/index.md
@@ -2704,7 +2704,7 @@ jobs:
         python-version: '3.11'
         
     - name: Cache dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}

--- a/docs/chapters/chapter08/index.md
+++ b/docs/chapters/chapter08/index.md
@@ -1352,7 +1352,7 @@ class AlertManager:
           python-version: ${{ matrix.python-version }}
       
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
@@ -1379,7 +1379,7 @@ class AlertManager:
           pytest tests/integration/ -v --junitxml=junit-integration.xml --cov=app --cov-append --cov-report=xml:coverage-integration.xml
       
       - name: Upload test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test-results-${{ matrix.python-version }}-${{ matrix.os }}
@@ -1412,7 +1412,7 @@ class AlertManager:
                  --html=performance-report.html --csv=performance
       
       - name: Upload performance results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: performance-results
           path: |

--- a/src/chapters/chapter05-3/index.md
+++ b/src/chapters/chapter05-3/index.md
@@ -2698,7 +2698,7 @@ jobs:
         python-version: '3.11'
         
     - name: Cache dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}

--- a/src/chapters/chapter08/index.md
+++ b/src/chapters/chapter08/index.md
@@ -1346,7 +1346,7 @@ class AlertManager:
           python-version: ${{ matrix.python-version }}
       
       - name: Cache dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
@@ -1373,7 +1373,7 @@ class AlertManager:
           pytest tests/integration/ -v --junitxml=junit-integration.xml --cov=app --cov-append --cov-report=xml:coverage-integration.xml
       
       - name: Upload test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test-results-${{ matrix.python-version }}-${{ matrix.os }}
@@ -1406,7 +1406,7 @@ class AlertManager:
                  --html=performance-report.html --csv=performance
       
       - name: Upload performance results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: performance-results
           path: |

--- a/templates/github-workflows/build-actions.yml
+++ b/templates/github-workflows/build-actions.yml
@@ -40,7 +40,7 @@ jobs:
         
     - name: Upload artifact
       if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@v4
       with:
         path: ./docs
 


### PR DESCRIPTION
## 概要
- 書籍本文および関連テンプレートに残る、公式 GitHub Actions の旧メジャー参照を更新
- このPRで実際に存在する記述のみを更新（存在しない記述は変更なし）

## 対象方針
- `actions/cache@v3` -> `actions/cache@v4`
- `actions/upload-artifact@v3` -> `actions/upload-artifact@v4`
- `actions/download-artifact@v3` -> `actions/download-artifact@v4`
- `actions/upload-pages-artifact@v2|v3` -> `actions/upload-pages-artifact@v4`
- `actions/deploy-pages@v2` -> `actions/deploy-pages@v4`
- `actions/dependency-review-action@v3` -> `actions/dependency-review-action@v4`
- `actions/configure-pages@v3` -> `actions/configure-pages@v5`

## 補足
- Issue: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102
- 書籍の記述例・テンプレート更新が主目的です。