### PR TITLE
CI記述例の @master 参照をバージョンタグへ更新

### DIFF
--- a/docs/appendices/appendix01/index.md
+++ b/docs/appendices/appendix01/index.md
@@ -922,7 +922,7 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@0.33.1
       with:
         scan-type: 'fs'
         scan-ref: '.'

--- a/docs/chapters/chapter08/index.md
+++ b/docs/chapters/chapter08/index.md
@@ -1515,7 +1515,7 @@ class AlertManager:
     if: github.event_name != 'pull_request'
     steps:
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.33.1
         with:
           image-ref: ${{ needs.build-and-push.outputs.image-tag }}
           format: 'sarif'

--- a/src/appendices/appendix01/index.md
+++ b/src/appendices/appendix01/index.md
@@ -917,7 +917,7 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@0.33.1
       with:
         scan-type: 'fs'
         scan-ref: '.'

--- a/src/chapters/chapter08/index.md
+++ b/src/chapters/chapter08/index.md
@@ -1509,7 +1509,7 @@ class AlertManager:
     if: github.event_name != 'pull_request'
     steps:
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.33.1
         with:
           image-ref: ${{ needs.build-and-push.outputs.image-tag }}
           format: 'sarif'


### PR DESCRIPTION
## 概要
- 書籍本文の GitHub Actions 記述例に残っている @master 参照を、明示バージョンタグへ更新

## 変更内容
- aquasecurity/trivy-action@master -> aquasecurity/trivy-action@0.33.1

## 補足
- 本PRは、当該リポジトリに実在する該当記述のみを更新しています。
- Issue: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102