### PR TITLE
CI記述例の codeql-action 参照を v4 に更新

### DIFF
--- a/docs/appendices/appendix01/index.md
+++ b/docs/appendices/appendix01/index.md
@@ -930,7 +930,7 @@ jobs:
         output: 'trivy-results.sarif'
     
     - name: Upload Trivy scan results
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: 'trivy-results.sarif'
 

--- a/docs/chapters/chapter08/index.md
+++ b/docs/chapters/chapter08/index.md
@@ -1522,7 +1522,7 @@ class AlertManager:
           output: 'trivy-image-results.sarif'
       
       - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-image-results.sarif'
 

--- a/src/appendices/appendix01/index.md
+++ b/src/appendices/appendix01/index.md
@@ -925,7 +925,7 @@ jobs:
         output: 'trivy-results.sarif'
     
     - name: Upload Trivy scan results
-      uses: github/codeql-action/upload-sarif@v2
+      uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: 'trivy-results.sarif'
 

--- a/src/chapters/chapter08/index.md
+++ b/src/chapters/chapter08/index.md
@@ -1516,7 +1516,7 @@ class AlertManager:
           output: 'trivy-image-results.sarif'
       
       - name: Upload Trivy scan results
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: 'trivy-image-results.sarif'
 


### PR DESCRIPTION
## 概要
- 書籍本文の GitHub Actions 記述例に残る `github/codeql-action/upload-sarif@v2` を `@v4` に更新

## 変更内容
- `github/codeql-action/upload-sarif@v2` -> `github/codeql-action/upload-sarif@v4`

## 補足
- 本PRは当該リポジトリに実在する記述のみ更新
- Issue: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102