### PR TITLE
CI記述例の Docker Actions 参照を v3 に更新

### DIFF
--- a/docs/chapters/chapter05-3/index.md
+++ b/docs/chapters/chapter05-3/index.md
@@ -1358,10 +1358,10 @@ jobs:
       uses: actions/checkout@v4
     
     - name: 🔧 Docker Buildx セットアップ
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
     
     - name: 🔐 Container Registry ログイン
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -2755,10 +2755,10 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
       
     - name: Log in to Container Registry
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}

--- a/docs/chapters/chapter10/index.md
+++ b/docs/chapters/chapter10/index.md
@@ -1654,7 +1654,7 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Log in to Container Registry
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}

--- a/src/chapters/chapter05-3/index.md
+++ b/src/chapters/chapter05-3/index.md
@@ -1353,10 +1353,10 @@ jobs:
       uses: actions/checkout@v4
     
     - name: 🔧 Docker Buildx セットアップ
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
     
     - name: 🔐 Container Registry ログイン
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -2749,10 +2749,10 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
       
     - name: Log in to Container Registry
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}

--- a/src/chapters/chapter10/index.md
+++ b/src/chapters/chapter10/index.md
@@ -1651,7 +1651,7 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Log in to Container Registry
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}


### PR DESCRIPTION
## 概要
- 書籍本文の Docker 関連 GitHub Actions 記述例で、`@v2` 参照を `@v3` に更新

## 変更内容
- `docker/setup-buildx-action@v2` -> `@v3`
- `docker/login-action@v2` -> `@v3`

## 補足
- 本PRは当該リポジトリに実在する記述のみ更新
- Issue: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102
