### PR TITLE
CI記述例の追加Action参照を更新

### DIFF
--- a/docs/appendices/appendix01/index.md
+++ b/docs/appendices/appendix01/index.md
@@ -912,7 +912,7 @@ jobs:
         pytest tests/ -v --cov=app --cov-report=xml
     
     - name: Upload coverage
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
         file: ./coverage.xml
 

--- a/docs/chapters/chapter05-3/index.md
+++ b/docs/chapters/chapter05-3/index.md
@@ -1338,7 +1338,7 @@ jobs:
         pytest tests/api/ -v
     
     - name: 📊 テストカバレッジアップロード
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
         file: ./coverage.xml
         fail_ci_if_error: true
@@ -2731,7 +2731,7 @@ jobs:
         pytest tests/ -v --cov=app --cov-report=xml
         
     - name: Upload coverage
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
         file: ./coverage.xml
 

--- a/src/appendices/appendix01/index.md
+++ b/src/appendices/appendix01/index.md
@@ -907,7 +907,7 @@ jobs:
         pytest tests/ -v --cov=app --cov-report=xml
     
     - name: Upload coverage
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
         file: ./coverage.xml
 

--- a/src/chapters/chapter05-3/index.md
+++ b/src/chapters/chapter05-3/index.md
@@ -1333,7 +1333,7 @@ jobs:
         pytest tests/api/ -v
     
     - name: 📊 テストカバレッジアップロード
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
         file: ./coverage.xml
         fail_ci_if_error: true
@@ -2725,7 +2725,7 @@ jobs:
         pytest tests/ -v --cov=app --cov-report=xml
         
     - name: Upload coverage
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
         file: ./coverage.xml
 


### PR DESCRIPTION
## 概要
- 書籍本文の GitHub Actions 記述例で、旧参照を更新

## 変更内容
- codecov/codecov-action@v5

## 補足
- 本PRは当該リポジトリに実在する記述のみ更新
- Issue: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102
