### PR TITLE
docs: actions/setup-python を v6 に更新

### DIFF
--- a/docs/appendices/appendix01/index.md
+++ b/docs/appendices/appendix01/index.md
@@ -894,7 +894,7 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
     

--- a/docs/chapters/chapter05-3/index.md
+++ b/docs/chapters/chapter05-3/index.md
@@ -1286,7 +1286,7 @@ jobs:
       uses: actions/checkout@v4
     
     - name: 🐍 Python環境セットアップ
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ env.PYTHON_VERSION }}
         cache: 'pip'
@@ -1481,7 +1481,7 @@ jobs:
       uses: actions/checkout@v4
     
     - name: 🐍 Python環境セットアップ
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     
@@ -2699,7 +2699,7 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
         

--- a/docs/chapters/chapter08/index.md
+++ b/docs/chapters/chapter08/index.md
@@ -1347,7 +1347,7 @@ class AlertManager:
       - uses: actions/checkout@v4
       
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       

--- a/docs/chapters/chapter10/index.md
+++ b/docs/chapters/chapter10/index.md
@@ -1594,7 +1594,7 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
     

--- a/src/appendices/appendix01/index.md
+++ b/src/appendices/appendix01/index.md
@@ -889,7 +889,7 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
     

--- a/src/chapters/chapter05-3/index.md
+++ b/src/chapters/chapter05-3/index.md
@@ -1281,7 +1281,7 @@ jobs:
       uses: actions/checkout@v4
     
     - name: 🐍 Python環境セットアップ
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ env.PYTHON_VERSION }}
         cache: 'pip'
@@ -1476,7 +1476,7 @@ jobs:
       uses: actions/checkout@v4
     
     - name: 🐍 Python環境セットアップ
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ env.PYTHON_VERSION }}
     
@@ -2693,7 +2693,7 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
         

--- a/src/chapters/chapter08/index.md
+++ b/src/chapters/chapter08/index.md
@@ -1341,7 +1341,7 @@ class AlertManager:
       - uses: actions/checkout@v4
       
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       

--- a/src/chapters/chapter10/index.md
+++ b/src/chapters/chapter10/index.md
@@ -1591,7 +1591,7 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
     


### PR DESCRIPTION
- Appendix/章5-3/章8/章10のWorkflow例で `actions/setup-python@v4` を `@v6` に更新
- `docs` と `src` を同期更新

関連: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102