### PR TITLE
docs: docker/build-push-action の例を v6 に更新

### DIFF
--- a/docs/chapters/chapter05-3/index.md
+++ b/docs/chapters/chapter05-3/index.md
@@ -1380,7 +1380,7 @@ jobs:
     
     - name: 🔨 Docker イメージビルド・プッシュ
       id: build
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v6
       with:
         context: .
         file: ./Dockerfile
@@ -2775,7 +2775,7 @@ jobs:
           type=sha
           
     - name: Build and push
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v6
       with:
         context: .
         push: true

--- a/docs/chapters/chapter10/index.md
+++ b/docs/chapters/chapter10/index.md
@@ -1661,14 +1661,14 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     
     - name: Build and push Backend
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v6
       with:
         context: ./backend
         push: true
         tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/backend:latest
     
     - name: Build and push Frontend  
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v6
       with:
         context: ./frontend
         push: true

--- a/src/chapters/chapter05-3/index.md
+++ b/src/chapters/chapter05-3/index.md
@@ -1375,7 +1375,7 @@ jobs:
     
     - name: 🔨 Docker イメージビルド・プッシュ
       id: build
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v6
       with:
         context: .
         file: ./Dockerfile
@@ -2769,7 +2769,7 @@ jobs:
           type=sha
           
     - name: Build and push
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v6
       with:
         context: .
         push: true

--- a/src/chapters/chapter10/index.md
+++ b/src/chapters/chapter10/index.md
@@ -1658,14 +1658,14 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     
     - name: Build and push Backend
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v6
       with:
         context: ./backend
         push: true
         tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/backend:latest
     
     - name: Build and push Frontend  
-      uses: docker/build-push-action@v4
+      uses: docker/build-push-action@v6
       with:
         context: ./frontend
         push: true


### PR DESCRIPTION
## 概要
- ドキュメント/サンプル内の `docker/build-push-action@v4` を `@v6` に更新
- 参照先を最新メジャー（`docker/build-push-action` latest: `v6.19.1`）へ追随

## 変更
- `docker/build-push-action@v4` -> `docker/build-push-action@v6`

Closes #102