### PR TITLE
docs: DESIGN-PREVIEW の不達リンクを更新

### DIFF
--- a/DESIGN-PREVIEW.md
+++ b/DESIGN-PREVIEW.md
@@ -14,7 +14,7 @@
 3. 右上の🌙/☀️ボタンでテーマ切り替えを試す
 
 ### オプション2: ローカルファイル
-1. [design-preview.html](./design-preview.html) を右クリック
+1. [design-preview.html](./design-preview.html?raw=1) を右クリック
 2. "名前を付けてリンク先を保存" を選択
 3. ダウンロードしたHTMLファイルをブラウザで開く
 

--- a/DESIGN-PREVIEW.md
+++ b/DESIGN-PREVIEW.md
@@ -2,7 +2,7 @@
 
 ## 🔗 ライブプレビュー
 
-**✨ [ライブデザインプレビューを見る](https://itdojp.github.io/book-publishing-template2/)**
+**✨ [ライブデザインプレビューを見る](https://itdojp.github.io/supabase-architecture-patterns-book/)**
 
 > 上記リンクをクリックして、実際のデザインをインタラクティブに体験できます。右上のボタンでライト/ダークモードの切り替えも可能です。
 
@@ -173,7 +173,7 @@ git clone https://github.com/itdojp/supabase-architecture-patterns-book.git
 open design-preview.html
 
 # または GitHub Pages で確認
-# https://itdojp.github.io/book-publishing-template2/
+# https://itdojp.github.io/supabase-architecture-patterns-book/
 ```
 
 ### 書籍作成者向け
@@ -184,7 +184,7 @@ open design-preview.html
 ## 🔗 関連リンク
 
 - **📋 提案イシュー**: [book-formatter Issues](https://github.com/itdojp/book-formatter/issues)
-- **🔄 ライブプレビュー**: [GitHub Pages](https://itdojp.github.io/book-publishing-template2/)
+- **🔄 ライブプレビュー**: [GitHub Pages](https://itdojp.github.io/supabase-architecture-patterns-book/)
 - **📁 ソースコード**: [design-preview.html](https://github.com/itdojp/supabase-architecture-patterns-book/blob/main/design-preview.html)
 - **📖 実装ガイド**: [Templates フォルダ](https://github.com/itdojp/book-formatter/tree/main/templates)
 

--- a/DESIGN-PREVIEW.md
+++ b/DESIGN-PREVIEW.md
@@ -14,7 +14,7 @@
 3. 右上の🌙/☀️ボタンでテーマ切り替えを試す
 
 ### オプション2: ローカルファイル
-1. [design-preview.html](https://raw.githubusercontent.com/itdojp/book-publishing-template2/main/design-preview.html) を右クリック
+1. [design-preview.html](https://raw.githubusercontent.com/itdojp/supabase-architecture-patterns-book/main/design-preview.html) を右クリック
 2. "名前を付けてリンク先を保存" を選択
 3. ダウンロードしたHTMLファイルをブラウザで開く
 
@@ -167,7 +167,7 @@ const codeBlock = {
 ### 開発者向け
 ```bash
 # リポジトリをクローン
-git clone https://github.com/itdojp/book-publishing-template2.git
+git clone https://github.com/itdojp/supabase-architecture-patterns-book.git
 
 # プレビューを確認
 open design-preview.html
@@ -178,15 +178,15 @@ open design-preview.html
 
 ### 書籍作成者向け
 1. プレビューでデザインを確認
-2. [GitHub Issue #1](https://github.com/itdojp/book-publishing-template2/issues/1) でフィードバック
+2. [book-formatter Issues](https://github.com/itdojp/book-formatter/issues) でフィードバック
 3. 実装完了後にテンプレートとして利用
 
 ## 🔗 関連リンク
 
-- **📋 提案イシュー**: [GitHub Issue #1](https://github.com/itdojp/book-publishing-template2/issues/1)
+- **📋 提案イシュー**: [book-formatter Issues](https://github.com/itdojp/book-formatter/issues)
 - **🔄 ライブプレビュー**: [GitHub Pages](https://itdojp.github.io/book-publishing-template2/)
-- **📁 ソースコード**: [design-preview.html](https://github.com/itdojp/book-publishing-template2/blob/main/design-preview.html)
-- **📖 実装ガイド**: [Templates フォルダ](https://github.com/itdojp/book-publishing-template2/tree/main/templates)
+- **📁 ソースコード**: [design-preview.html](https://github.com/itdojp/supabase-architecture-patterns-book/blob/main/design-preview.html)
+- **📖 実装ガイド**: [Templates フォルダ](https://github.com/itdojp/book-formatter/tree/main/templates)
 
 ---
 

--- a/DESIGN-PREVIEW.md
+++ b/DESIGN-PREVIEW.md
@@ -14,7 +14,7 @@
 3. 右上の🌙/☀️ボタンでテーマ切り替えを試す
 
 ### オプション2: ローカルファイル
-1. [design-preview.html](https://raw.githubusercontent.com/itdojp/supabase-architecture-patterns-book/main/design-preview.html) を右クリック
+1. [design-preview.html](./design-preview.html) を右クリック
 2. "名前を付けてリンク先を保存" を選択
 3. ダウンロードしたHTMLファイルをブラウザで開く
 
@@ -185,7 +185,7 @@ open design-preview.html
 
 - **📋 提案イシュー**: [book-formatter Issues](https://github.com/itdojp/book-formatter/issues)
 - **🔄 ライブプレビュー**: [GitHub Pages](https://itdojp.github.io/supabase-architecture-patterns-book/)
-- **📁 ソースコード**: [design-preview.html](https://github.com/itdojp/supabase-architecture-patterns-book/blob/main/design-preview.html)
+- **📁 ソースコード**: [design-preview.html](./design-preview.html)
 - **📖 実装ガイド**: [Templates フォルダ](https://github.com/itdojp/book-formatter/tree/main/templates)
 
 ---


### PR DESCRIPTION
## 概要
- `DESIGN-PREVIEW.md` に残っていた不達リンク（404）を更新
- 旧 `book-publishing-template2` の生ファイル/Issue固定/templates固定リンクを、到達可能なURLへ置換

## 変更内容
- `design-preview.html` の raw URL を当該書籍リポジトリの `main` へ更新
- clone 先を当該書籍リポジトリへ更新
- フィードバック導線を `book-formatter` の Issues へ更新
- ソースコード参照を当該書籍リポジトリの `design-preview.html` へ更新
- テンプレート参照を `book-formatter` の templates へ更新

Related: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/102