### PR TITLE
fix: Step1のコードフェンス閉じ忘れを修正

### DIFF
--- a/src/chapters/chapter05-3/index.md
+++ b/src/chapters/chapter05-3/index.md
@@ -213,6 +213,8 @@ def get_user_dashboard_data(user_id: int):
         "completed_tasks": 127,
         "team_members": 8
     }
+```
+
 **🔰 初心者向け解説**：
 
 | 概念 | 何をしているか | 身近な例 |


### PR DESCRIPTION
## 変更内容\n- Step1のコードブロック（```python）が閉じられないまま次の説明/Step2に続いており、後続の ```python がネスト扱いになってレンダリングが崩れる可能性があったため修正しました。\n- Step1末尾に閉じフェンス（```）を追加しています。\n\n## 対象\n- src/chapters/chapter05-3/index.md