### PR TITLE
docs: Built with を book-formatter に更新

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -93,6 +93,6 @@ Email: [knowledge@itdo.jp](mailto:knowledge@itdo.jp)
 
 ---
 
-Built with [Book Publishing Template v3.0](https://github.com/itdojp/book-publishing-template2)
+Built with [book-formatter](https://github.com/itdojp/book-formatter)
 
 {% include page-navigation.html %}


### PR DESCRIPTION
## 目的
- GitHub Pages 上の `Built with ...` 表記を、現行の `book-formatter` に合わせます。
- 旧テンプレ（`book-publishing-template2`）へのリンクはリポジトリが非公開のため、読者導線として不適切なので置き換えます。

## 変更内容
- `docs/index.md` の `Built with` リンクを `itdojp/book-formatter` に更新。
