### PR TITLE
Drawer（TOC）: 現在位置を自動スクロール

### DIFF
--- a/docs/_layouts/book.html
+++ b/docs/_layouts/book.html
@@ -218,67 +218,122 @@
         });
     </script>
 
-    <script>
+        <script>
         // Auto-scroll active TOC into view when opening the drawer.
-        document.addEventListener('DOMContentLoaded', function() {
-            var cb = document.getElementById('sidebar-toggle-checkbox');
-            if (!cb) return;
+        (function() {
+            function initTocAutoScroll() {
+                var cb = document.getElementById('sidebar-toggle-checkbox');
+                if (!cb) return;
 
-            function normalizePath(p) {
-                var path = String(p || '').replace(/index\.html$/, '');
-                if (path.length > 1) {
-                    path = path.replace(/\/+$/, '');
+                function normalizePath(p) {
+                    var path = String(p || '').replace(/index\.html$/, '');
+                    // Remove trailing slashes for non-root paths so `/foo` and `/foo/` compare equal.
+                    if (path.length > 1) {
+                        path = path.replace(/\/+$/, '');
+                    }
+                    // Ensure we always return at least '/'.
+                    return path || '/';
                 }
-                return path || '/';
-            }
 
-            function findActiveTocLink() {
-                var current = normalizePath(window.location.pathname);
-                var actives = document.querySelectorAll('a.toc-link.active');
-                if (!actives || actives.length === 0) return null;
-
-                for (var i = 0; i < actives.length; i++) {
+                function isMobileDrawer() {
                     try {
+                        if (typeof window.matchMedia === 'function') {
+                            return window.matchMedia('(max-width: 1024px)').matches;
+                        }
+                    } catch (_) {}
+                    return typeof window.innerWidth === 'number' ? window.innerWidth <= 1024 : true;
+                }
+
+                function findActiveTocLink() {
+                    var current = normalizePath(window.location.pathname);
+                    var actives = document.querySelectorAll('a.toc-link.active');
+                    if (!actives || actives.length === 0) return null;
+
+                    for (var i = 0; i < actives.length; i++) {
                         var a = actives[i];
-                        var pathname = normalizePath(new URL(a.href, window.location.origin).pathname);
-                        if (pathname === current) return a;
+                        if (!a || !a.href) continue;
+                        try {
+                            var pathname = normalizePath(new URL(a.href).pathname);
+                            if (pathname === current) return a;
+                        } catch (_) {
+                            // Intentionally ignore malformed URLs; fall back to the first active TOC entry.
+                        }
+                    }
+                    return actives[0];
+                }
+
+                function ensureActiveTocVisible() {
+                    // If the drawer is closed while we are scheduled, do nothing.
+                    if (!cb.checked) return;
+                    if (!isMobileDrawer()) return;
+
+                    var active = findActiveTocLink();
+                    if (!active) return;
+
+                    var sidebar = active.closest('.book-sidebar') || document.getElementById('sidebar');
+                    if (!sidebar) return;
+
+                    try {
+                        var linkRect = active.getBoundingClientRect();
+                        var sidebarRect = sidebar.getBoundingClientRect();
+
+                        // Derive scroll margin from sidebar padding so behavior follows CSS.
+                        // Fallback to 8px if padding is not available or not parsable.
+                        var marginTop = 8;
+                        var marginBottom = 8;
+                        try {
+                            if (window.getComputedStyle) {
+                                var cs = window.getComputedStyle(sidebar);
+                                if (cs) {
+                                    var pt = parseFloat(cs.paddingTop);
+                                    var pb = parseFloat(cs.paddingBottom);
+                                    if (!isNaN(pt)) marginTop = pt;
+                                    if (!isNaN(pb)) marginBottom = pb;
+                                }
+                            }
+                        } catch (_) {}
+
+                        var top = sidebarRect.top + marginTop;
+                        var bottom = sidebarRect.bottom - marginBottom;
+                        // Scroll when any part of the active link is outside the visible bounds.
+                        var outOfView = linkRect.top < top || linkRect.bottom > bottom;
+
+                        if (outOfView && typeof active.scrollIntoView === 'function') {
+                            try {
+                                active.scrollIntoView({ block: 'center', behavior: 'auto' });
+                            } catch (e) {
+                                // Fallback for browsers that do not support the options-object signature.
+                                active.scrollIntoView();
+                            }
+                        }
                     } catch (_) {}
                 }
-                return actives[0];
+
+                function scheduleEnsure() {
+                    // Next tick (no transition) and after a short delay (CSS transitions/focus side-effects).
+                    setTimeout(ensureActiveTocVisible, 0);
+                    setTimeout(ensureActiveTocVisible, 350);
+                }
+
+                cb.addEventListener('change', function() {
+                    if (!cb.checked) return;
+                    scheduleEnsure();
+                });
+
+                // If the drawer is already open (bfcache/restore), ensure once.
+                if (cb.checked) {
+                    scheduleEnsure();
+                }
             }
 
-            function ensureActiveTocVisible() {
-                // If the drawer is closed while we are scheduled, do nothing.
-                if (!cb.checked) return;
-
-                var active = findActiveTocLink();
-                if (!active) return;
-
-                var sidebar = active.closest('.book-sidebar') || document.getElementById('sidebar');
-                if (!sidebar) return;
-
-                try {
-                    var linkRect = active.getBoundingClientRect();
-                    var sidebarRect = sidebar.getBoundingClientRect();
-                    var margin = 8;
-                    var top = sidebarRect.top + margin;
-                    var bottom = sidebarRect.bottom - margin;
-                    // Scroll when any part of the active link is outside the visible bounds.
-                    var outOfView = linkRect.top < top || linkRect.bottom > bottom;
-
-                    if (outOfView && typeof active.scrollIntoView === 'function') {
-                        active.scrollIntoView({ block: 'center', behavior: 'auto' });
-                    }
-                } catch (_) {}
+            if (document.readyState === 'loading') {
+                document.addEventListener('DOMContentLoaded', initTocAutoScroll);
+            } else {
+                initTocAutoScroll();
             }
-
-            cb.addEventListener('change', function() {
-                if (!cb.checked) return;
-                // Wait a tick for CSS to apply and the sidebar to become visible.
-                setTimeout(ensureActiveTocVisible, 0);
-            });
-        });
+        })();
     </script>
+
 
 </body>
 </html>

--- a/docs/_layouts/book.html
+++ b/docs/_layouts/book.html
@@ -218,5 +218,67 @@
         });
     </script>
 
+    <script>
+        // Auto-scroll active TOC into view when opening the drawer.
+        document.addEventListener('DOMContentLoaded', function() {
+            var cb = document.getElementById('sidebar-toggle-checkbox');
+            if (!cb) return;
+
+            function normalizePath(p) {
+                var path = String(p || '').replace(/index\.html$/, '');
+                if (path.length > 1) {
+                    path = path.replace(/\/+$/, '');
+                }
+                return path || '/';
+            }
+
+            function findActiveTocLink() {
+                var current = normalizePath(window.location.pathname);
+                var actives = document.querySelectorAll('a.toc-link.active');
+                if (!actives || actives.length === 0) return null;
+
+                for (var i = 0; i < actives.length; i++) {
+                    try {
+                        var a = actives[i];
+                        var pathname = normalizePath(new URL(a.href, window.location.origin).pathname);
+                        if (pathname === current) return a;
+                    } catch (_) {}
+                }
+                return actives[0];
+            }
+
+            function ensureActiveTocVisible() {
+                // If the drawer is closed while we are scheduled, do nothing.
+                if (!cb.checked) return;
+
+                var active = findActiveTocLink();
+                if (!active) return;
+
+                var sidebar = active.closest('.book-sidebar') || document.getElementById('sidebar');
+                if (!sidebar) return;
+
+                try {
+                    var linkRect = active.getBoundingClientRect();
+                    var sidebarRect = sidebar.getBoundingClientRect();
+                    var margin = 8;
+                    var top = sidebarRect.top + margin;
+                    var bottom = sidebarRect.bottom - margin;
+                    // Scroll when any part of the active link is outside the visible bounds.
+                    var outOfView = linkRect.top < top || linkRect.bottom > bottom;
+
+                    if (outOfView && typeof active.scrollIntoView === 'function') {
+                        active.scrollIntoView({ block: 'center', behavior: 'auto' });
+                    }
+                } catch (_) {}
+            }
+
+            cb.addEventListener('change', function() {
+                if (!cb.checked) return;
+                // Wait a tick for CSS to apply and the sidebar to become visible.
+                setTimeout(ensureActiveTocVisible, 0);
+            });
+        });
+    </script>
+
 </body>
 </html>

--- a/docs/_layouts/book.html
+++ b/docs/_layouts/book.html
@@ -218,7 +218,7 @@
         });
     </script>
 
-        <script>
+            <script>
         // Auto-scroll active TOC into view when opening the drawer.
         (function() {
             function initTocAutoScroll() {
@@ -240,7 +240,9 @@
                         if (typeof window.matchMedia === 'function') {
                             return window.matchMedia('(max-width: 1024px)').matches;
                         }
-                    } catch (_) {}
+                    } catch (_) {
+                        // Ignore matchMedia failures and fall back to window.innerWidth.
+                    }
                     return typeof window.innerWidth === 'number' ? window.innerWidth <= 1024 : true;
                 }
 
@@ -291,7 +293,9 @@
                                     if (!isNaN(pb)) marginBottom = pb;
                                 }
                             }
-                        } catch (_) {}
+                        } catch (_) {
+                            // Ignore style parsing issues; keep fallback margins.
+                        }
 
                         var top = sidebarRect.top + marginTop;
                         var bottom = sidebarRect.bottom - marginBottom;
@@ -306,7 +310,9 @@
                                 active.scrollIntoView();
                             }
                         }
-                    } catch (_) {}
+                    } catch (_) {
+                        // Best-effort UX: ignore measurement errors.
+                    }
                 }
 
                 function scheduleEnsure() {
@@ -333,6 +339,7 @@
             }
         })();
     </script>
+
 
 
 </body>


### PR DESCRIPTION
Refs:
- it-engineer-knowledge-architecture Issue #122: https://github.com/itdojp/it-engineer-knowledge-architecture/issues/122
- book-formatter PR #85（仕様/実装元）: https://github.com/itdojp/book-formatter/pull/85

## 変更内容
- モバイルで Drawer（TOC）を開いた直後に、現在位置の TOC（`a.toc-link.active`）が可視領域外の場合は `scrollIntoView` で中央付近に移動します。
- 既に可視領域内ならスクロールしません。

## 目的
- Drawer を開いた直後に「現在位置」が見えず手動スクロールが必要になるケースを解消します。
