### PR TITLE
docs: fix broken links and numbering (bookqa #126)

### DIFF
--- a/docs/appendices/appendix01/index.md
+++ b/docs/appendices/appendix01/index.md
@@ -34,7 +34,7 @@ title: "付録B: 参考資料"
 
 ---
 
-## A. 環境構築スクリプト集
+## A. 環境構築スクリプト集 {#appendix-env-setup-scripts}
 
 ### A.1 Supabase開発環境セットアップ
 
@@ -1121,7 +1121,7 @@ settings = Settings()
 - [ ] CDNが設定されているか
 - [ ] 監視・アラートが設定されているか
 
-### C.3 運用チェックリスト
+### C.3 運用チェックリスト {#operational-checklists}
 
 #### デプロイ前
 
@@ -1528,5 +1528,5 @@ LIMIT 20;
 **📍 最終ナビゲーション**
 - **📚 目次**: [📖 学習ガイド]({{ '/introduction/' | relative_url }})
 - **🏠 全章**: [Chapter 1-10]({{ '/introduction/' | relative_url }}) での実装時に参照
-- **🔧 関連リソース**: [動作検証]({{ site.baseurl }}/src/) | [チェックリスト]({{ '/operational_checklists.html' | relative_url }}) | [トラブルシューティング]({{ '/troubleshooting_guide.html' | relative_url }})
+- **🔧 関連リソース**: [動作検証]({{ '/guides/code-verification/' | relative_url }}) | [チェックリスト]({{ '/appendices/appendix01/' | relative_url }}#operational-checklists) | [トラブルシューティング]({{ '/guides/troubleshooting/' | relative_url }})
 - **🌐 コミュニティ**: [Supabase公式](https://supabase.com) | [GitHub](https://github.com/supabase/supabase)

--- a/docs/chapters/chapter01/index.md
+++ b/docs/chapters/chapter01/index.md
@@ -1139,4 +1139,4 @@ Chapter 2では、「病院のカルテシステム」を例に、以下を学�
 - **📚 目次**: [📖 学習ガイド]({{ '/introduction/' | relative_url }})
 - **➡️ 次の章**: [Chapter 2: 認証システムの実装]({{ '/chapters/chapter02/' | relative_url }})  
 - **🏠 関連章**: [Chapter 3-5: アーキテクチャパターン]({{ '/chapters/chapter03/' | relative_url }})
-- **🔧 リソース**: [動作検証]({{ site.baseurl }}/src/) | [トラブルシューティング]({{ '/troubleshooting_guide.html' | relative_url }})
+- **🔧 リソース**: [動作検証]({{ '/guides/code-verification/' | relative_url }}) | [トラブルシューティング]({{ '/guides/troubleshooting/' | relative_url }})

--- a/docs/chapters/chapter02/index.md
+++ b/docs/chapters/chapter02/index.md
@@ -1027,7 +1027,7 @@ Chapter 3のクライアントサイド実装をスムーズに進めるため�
 
 #### **準備が不安な場合**
 - 🔍 [Supabase公式チュートリアル](https://supabase.com/docs/guides/getting-started) を実施
-- 📚 [付録：環境構築]({{ site.baseurl }}/appendix.md#a-環境構築スクリプト集) で開発環境を準備
+- 📚 [付録：環境構築]({{ '/appendices/appendix01/' | relative_url }}#appendix-env-setup-scripts) で開発環境を準備
 - 💬 不明点は [GitHub Discussions](https://github.com/supabase/supabase/discussions) で質問
 
 ---
@@ -1036,5 +1036,5 @@ Chapter 3のクライアントサイド実装をスムーズに進めるため�
 - **📚 目次**: [📖 学習ガイド]({{ '/introduction/' | relative_url }})
 - **⬅️ 前の章**: [Chapter 1: Supabaseアーキテクチャ理解]({{ '/chapters/chapter01/' | relative_url }})  
 - **➡️ 次の章**: [Chapter 3: クライアントサイド実装]({{ '/chapters/chapter03/' | relative_url }})
-- **🏠 関連章**: [Chapter 7: セキュリティ強化]({{ '/chapters/chapter07/' | relative_url }}) | [全体設計]({{ '/pattern_selection_guide.html' | relative_url }})
-- **🔧 リソース**: [認証テンプレート]({{ site.baseurl }}/src/) | [セキュリティ・ガイド]({{ '/troubleshooting_guide.html' | relative_url }})
+- **🏠 関連章**: [Chapter 7: セキュリティ強化]({{ '/chapters/chapter07/' | relative_url }}) | [全体設計]({{ '/guides/pattern-selection/' | relative_url }})
+- **🔧 リソース**: [認証テンプレート]({{ site.repository }}/tree/main/src/examples/) | [セキュリティ・ガイド]({{ '/guides/troubleshooting/' | relative_url }})

--- a/docs/chapters/chapter03/index.md
+++ b/docs/chapters/chapter03/index.md
@@ -2190,7 +2190,7 @@ def main(page: ft.Page):
 ### 関連リソース
 - [Flet公式ドキュメント](https://flet.dev/docs/)
 - [Supabase Python クライアント](https://supabase.com/docs/reference/python/introduction)
-- [環境構築ガイド]({{ '/environment_setup_guide.html' | relative_url }})
+- [環境構築ガイド]({{ '/appendices/appendix01/' | relative_url }}#appendix-env-setup-scripts)
 
 ---
 
@@ -2332,11 +2332,11 @@ Chapter 4では、「病院薬剤管理システム」を例に、**プレハブ
 - **📚 目次**: [📖 学習ガイド]({{ '/introduction/' | relative_url }})
 - **⬅️ 前の章**: [Chapter 2: 認証システム]({{ '/chapters/chapter02/' | relative_url }})
 - **➡️ 次の章**: [Chapter 4: Edge Functions活用]({{ '/chapters/chapter04/' | relative_url }})
-- **🏠 同レベル**: [Chapter 5: API Server実装]({{ '/chapter05-1.html' | relative_url }})
-- **🔧 実践**: [サンプルコード]({{ site.baseurl }}/src/chapter03-task-manager/) | [動作検証]({{ site.baseurl }}/src/verify_apps.py)
+- **🏠 同レベル**: [Chapter 5: API Server実装]({{ '/chapters/chapter05-1/' | relative_url }})
+- **🔧 実践**: [サンプルコード]({{ site.repository }}/tree/main/src/examples/pattern1/) | [動作検証]({{ '/guides/code-verification/' | relative_url }})
 
 ### 📚 **関連リソース**
-- 🔧 [トラブルシューティング]({{ '/troubleshooting_guide.html' | relative_url }})
-- 🎯 [パターン選択ガイド]({{ '/pattern_selection_guide.html' | relative_url }})  
-- 📋 [運用チェックリスト]({{ '/operational_checklists.html' | relative_url }})
-- 🔍 [コード検証ガイド]({{ '/code_verification.html' | relative_url }})
+- 🔧 [トラブルシューティング]({{ '/guides/troubleshooting/' | relative_url }})
+- 🎯 [パターン選択ガイド]({{ '/guides/pattern-selection/' | relative_url }})  
+- 📋 [運用チェックリスト]({{ '/appendices/appendix01/' | relative_url }}#operational-checklists)
+- 🔍 [コード検証ガイド]({{ '/guides/code-verification/' | relative_url }})

--- a/docs/chapters/chapter04/index.md
+++ b/docs/chapters/chapter04/index.md
@@ -8,7 +8,7 @@ title: "Chapter 4: パターン2 - Edge Functions活用 ⚡"
 ---
 **📚 目次に戻る**: [📖 学習ガイド]({{ '/introduction/' | relative_url }})  
 **⬅️ 前の章**: [Chapter 3: パターン1 - クライアントサイド実装]({{ '/chapters/chapter03/' | relative_url }})  
-**➡️ 次の章**: [Chapter 5: パターン3 - 独立API サーバー]({{ '/chapter05-1.html' | relative_url }})  
+**➡️ 次の章**: [Chapter 5: パターン3 - 独立API サーバー]({{ '/chapters/chapter05-1/' | relative_url }})  
 **🏗️ アーキテクチャ**: Edge Functions（サーバーレス関数）  
 **🎯 学習レベル**: 🌱 基礎 | 🚀 応用 | 💪 発展  
 **⏱️ 推定学習時間**: 4〜6時間  
@@ -3322,6 +3322,6 @@ Chapter 5では、「**大病院の基幹システム**」を例に、エンタ�
 **📍 ナビゲーション**
 - **📚 目次**: [📖 学習ガイド]({{ '/introduction/' | relative_url }})
 - **⬅️ 前の章**: [Chapter 3: クライアントサイド実装]({{ '/chapters/chapter03/' | relative_url }})  
-- **➡️ 次の章**: [Chapter 5: 独立API サーバー]({{ '/chapter05-1.html' | relative_url }})
+- **➡️ 次の章**: [Chapter 5: 独立API サーバー]({{ '/chapters/chapter05-1/' | relative_url }})
 - **🏠 関連章**: [Chapter 1: Supabase基礎]({{ '/chapters/chapter01/' | relative_url }}) | [Chapter 6: パフォーマンス]({{ '/chapters/chapter06/' | relative_url }})
-- **🔧 リソース**: [動作検証]({{ site.baseurl }}/src/) | [トラブルシューティング]({{ '/troubleshooting_guide.html' | relative_url }})
+- **🔧 リソース**: [動作検証]({{ '/guides/code-verification/' | relative_url }}) | [トラブルシューティング]({{ '/guides/troubleshooting/' | relative_url }})

--- a/docs/chapters/chapter05-1/index.md
+++ b/docs/chapters/chapter05-1/index.md
@@ -2277,6 +2277,6 @@ Chapter 5-2以降で学ぶ発展的機能：
 **📍 ナビゲーション**
 - **📚 目次**: [📖 学習ガイド]({{ '/introduction/' | relative_url }})
 - **⬅️ 前の章**: [Chapter 4: Edge Functions活用]({{ '/chapters/chapter04/' | relative_url }})  
-- **➡️ 続き**: [Chapter 5-2: マルチテナント実装]({{ '/chapter05-2.html' | relative_url }})
+- **➡️ 続き**: [Chapter 5-2: マルチテナント実装]({{ '/chapters/chapter05-2/' | relative_url }})
 - **🏠 関連章**: [Chapter 1: Supabase基礎]({{ '/chapters/chapter01/' | relative_url }}) | [Chapter 6: パフォーマンス]({{ '/chapters/chapter06/' | relative_url }})
-- **🔧 リソース**: [動作検証]({{ site.baseurl }}/src/) | [トラブルシューティング]({{ '/troubleshooting_guide.html' | relative_url }})
+- **🔧 リソース**: [動作検証]({{ '/guides/code-verification/' | relative_url }}) | [トラブルシューティング]({{ '/guides/troubleshooting/' | relative_url }})

--- a/docs/chapters/chapter05-2/index.md
+++ b/docs/chapters/chapter05-2/index.md
@@ -7,8 +7,8 @@ title: "Chapter 5-2: マルチテナンシーと複雑ビジネスロジック �
 
 ---
 **📚 目次に戻る**: [📖 学習ガイド]({{ '/introduction/' | relative_url }})  
-**⬅️ 前の章**: [Chapter 5-1: 独立APIサーバー基礎]({{ '/chapter05-1.html' | relative_url }})  
-**➡️ 次の章**: [Chapter 5-3: 本番運用機能]({{ '/chapter05-3.html' | relative_url }})  
+**⬅️ 前の章**: [Chapter 5-1: 独立APIサーバー基礎]({{ '/chapters/chapter05-1/' | relative_url }})  
+**➡️ 次の章**: [Chapter 5-3: 本番運用機能]({{ '/chapters/chapter05-3/' | relative_url }})  
 **🏗️ アーキテクチャ**: 独立APIサーバー（FastAPI + マルチテナント）  
 **🎯 学習レベル**: 🌱 基礎 | 🚀 応用 | 💪 発展  
 **⏱️ 推定学習時間**: 4〜6時間  
@@ -1790,7 +1790,7 @@ Chapter 5-3で学ぶ本番運用機能の前提知識：
 
 **📍 ナビゲーション**
 - **📚 目次**: [📖 学習ガイド]({{ '/introduction/' | relative_url }})
-- **⬅️ 前の章**: [Chapter 5-1: 独立APIサーバー基礎]({{ '/chapter05-1.html' | relative_url }})  
-- **➡️ 次の章**: [Chapter 5-3: 本番運用機能]({{ '/chapter05-3.html' | relative_url }})
+- **⬅️ 前の章**: [Chapter 5-1: 独立APIサーバー基礎]({{ '/chapters/chapter05-1/' | relative_url }})  
+- **➡️ 次の章**: [Chapter 5-3: 本番運用機能]({{ '/chapters/chapter05-3/' | relative_url }})
 - **🏠 関連章**: [Chapter 6: パフォーマンス最適化]({{ '/chapters/chapter06/' | relative_url }}) | [Chapter 8: 運用監視]({{ '/chapters/chapter08/' | relative_url }})
-- **🔧 リソース**: [マルチテナント設計]({{ '/src/' | relative_url }}) | [運用チェックリスト]({{ '/operational_checklists.html' | relative_url }})
+- **🔧 リソース**: [マルチテナント設計]({{ site.repository }}/tree/main/src/examples/pattern3/) | [運用チェックリスト]({{ '/appendices/appendix01/' | relative_url }}#operational-checklists)

--- a/docs/chapters/chapter05-3/index.md
+++ b/docs/chapters/chapter05-3/index.md
@@ -7,8 +7,8 @@ title: "Chapter 5-3: 拡張性設計とパフォーマンス最適化 📈"
 
 ---
 **📚 目次に戻る**: [📖 学習ガイド]({{ '/introduction/' | relative_url }})  
-**⬅️ 前の章**: [Chapter 5-2: マルチテナンシーと複雑ビジネスロジック]({{ '/chapter05-2.html' | relative_url }})  
-**➡️ 次の章**: [Chapter 5-4: RAG/ベクトル検索アーキテクチャ]({{ '/chapter05-4.html' | relative_url }})  
+**⬅️ 前の章**: [Chapter 5-2: マルチテナンシーと複雑ビジネスロジック]({{ '/chapters/chapter05-2/' | relative_url }})  
+**➡️ 次の章**: [Chapter 5-4: RAG/ベクトル検索アーキテクチャ]({{ '/chapters/chapter05-4/' | relative_url }})  
 **🏗️ アーキテクチャ**: 独立APIサーバー（FastAPI + スケーリング・最適化）  
 **🎯 学習レベル**: 🌱 基礎 | 🚀 応用 | 💪 発展  
 **⏱️ 推定学習時間**: 5〜7時間  
@@ -3972,7 +3972,7 @@ Chapter 6では、「**F1マシンのチューニング・エンジニア**」�
 
 **📍 ナビゲーション**
 - **📚 目次**: [📖 学習ガイド]({{ '/introduction/' | relative_url }})
-- **⬅️ 前の章**: [Chapter 5-2: マルチテナンシーと複雑ビジネスロジック]({{ '/chapter05-2.html' | relative_url }})  
+- **⬅️ 前の章**: [Chapter 5-2: マルチテナンシーと複雑ビジネスロジック]({{ '/chapters/chapter05-2/' | relative_url }})  
 - **➡️ 次の章**: [Chapter 6: パフォーマンス最適化]({{ '/chapters/chapter06/' | relative_url }})
-- **🏠 関連章**: [Chapter 5-1: APIサーバー基礎]({{ '/chapter05-1.html' | relative_url }}) | [Chapter 8: 運用監視]({{ '/chapters/chapter08/' | relative_url }})
-- **🔧 リソース**: [スケーリング設計]({{ site.baseurl }}/src/) | [運用チェックリスト]({{ '/operational_checklists.html' | relative_url }})
+- **🏠 関連章**: [Chapter 5-1: APIサーバー基礎]({{ '/chapters/chapter05-1/' | relative_url }}) | [Chapter 8: 運用監視]({{ '/chapters/chapter08/' | relative_url }})
+- **🔧 リソース**: [スケーリング設計]({{ site.repository }}/tree/main/src/examples/performance/) | [運用チェックリスト]({{ '/appendices/appendix01/' | relative_url }}#operational-checklists)

--- a/docs/chapters/chapter05-4/index.md
+++ b/docs/chapters/chapter05-4/index.md
@@ -7,7 +7,7 @@ title: "Chapter 5-4: RAG/ベクトル検索アーキテクチャ 🧠"
 
 ---
 **📚 目次に戻る**: [📖 学習ガイド]({{ '/introduction/' | relative_url }})  
-**⬅️ 前の章**: [Chapter 5-3: 本番運用機能]({{ '/chapter05-3.html' | relative_url }})  
+**⬅️ 前の章**: [Chapter 5-3: 本番運用機能]({{ '/chapters/chapter05-3/' | relative_url }})  
 **➡️ 次の章**: [Chapter 6: パフォーマンス最適化]({{ '/chapters/chapter06/' | relative_url }})  
 **🏗️ アーキテクチャ**: RAG / ベクトル検索 / 監査ログ  
 **🎯 学習レベル**: 🌱 基礎 | 🚀 応用 | 💪 発展  

--- a/docs/chapters/chapter06/index.md
+++ b/docs/chapters/chapter06/index.md
@@ -7,7 +7,7 @@ title: "Chapter 6: パフォーマンス最適化（システムの高速化マ�
 
 ---
 **📚 目次に戻る**: [📖 学習ガイド]({{ '/introduction/' | relative_url }})  
-**⬅️ 前の章**: [Chapter 5-4: RAG/ベクトル検索アーキテクチャ]({{ '/chapter05-4.html' | relative_url }})  
+**⬅️ 前の章**: [Chapter 5-4: RAG/ベクトル検索アーキテクチャ]({{ '/chapters/chapter05-4/' | relative_url }})  
 **➡️ 次の章**: [Chapter 7: セキュリティ強化]({{ '/chapters/chapter07/' | relative_url }})  
 **🎯 学習フェーズ**: Part III - 実装・運用編（パフォーマンス）  
 **🎯 学習レベル**: 🌱 基礎 | 🚀 応用 | 💪 発展  
@@ -3632,7 +3632,7 @@ Chapter 7では、「**銀行の金庫システム**」並みの堅牢なセキ�
 
 **📍 ナビゲーション**
 - **📚 目次**: [📖 学習ガイド]({{ '/introduction/' | relative_url }})
-- **⬅️ 前の章**: [Chapter 5-4: RAG/ベクトル検索アーキテクチャ]({{ '/chapter05-4.html' | relative_url }})  
+- **⬅️ 前の章**: [Chapter 5-4: RAG/ベクトル検索アーキテクチャ]({{ '/chapters/chapter05-4/' | relative_url }})  
 - **➡️ 次の章**: [Chapter 7: セキュリティ強化]({{ '/chapters/chapter07/' | relative_url }})
-- **🏠 関連章**: [Chapter 5: 独立API サーバー]({{ '/chapter05-1.html' | relative_url }}) | [Chapter 8: 運用監視]({{ '/chapters/chapter08/' | relative_url }})
-- **🔧 リソース**: [動作検証]({{ site.baseurl }}/src/) | [パフォーマンス・チェックリスト]({{ '/operational_checklists.html' | relative_url }})
+- **🏠 関連章**: [Chapter 5: 独立API サーバー]({{ '/chapters/chapter05-1/' | relative_url }}) | [Chapter 8: 運用監視]({{ '/chapters/chapter08/' | relative_url }})
+- **🔧 リソース**: [動作検証]({{ '/guides/code-verification/' | relative_url }}) | [パフォーマンス・チェックリスト]({{ '/appendices/appendix01/' | relative_url }}#operational-checklists)

--- a/docs/chapters/chapter07/index.md
+++ b/docs/chapters/chapter07/index.md
@@ -1232,4 +1232,4 @@ Chapter 8では、「**病院の生命維持管理システム**」レベルの�
 - **⬅️ 前の章**: [Chapter 6: パフォーマンス最適化]({{ '/chapters/chapter06/' | relative_url }})  
 - **➡️ 次の章**: [Chapter 8: 運用監視と自動化]({{ '/chapters/chapter08/' | relative_url }})
 - **🏠 関連章**: [Chapter 1: 認証基礎]({{ '/chapters/chapter01/' | relative_url }}) | [Chapter 9: 演習]({{ '/chapters/chapter09/' | relative_url }})
-- **🔧 リソース**: [セキュリティ・チェックリスト]({{ '/operational_checklists.html' | relative_url }}) | [脅威対策ガイド]({{ '/troubleshooting_guide.html' | relative_url }})
+- **🔧 リソース**: [セキュリティ・チェックリスト]({{ '/appendices/appendix01/' | relative_url }}#operational-checklists) | [脅威対策ガイド]({{ '/guides/troubleshooting/' | relative_url }})

--- a/docs/chapters/chapter08/index.md
+++ b/docs/chapters/chapter08/index.md
@@ -3070,7 +3070,7 @@ class ComprehensiveMonitor:
 
 ## トラブルシューティング
 
-### 8.4.1 CI/CDパイプライン障害対応
+### 8.5.1 CI/CDパイプライン障害対応
 
 #### パイプライン実行失敗の診断手順
 
@@ -3292,7 +3292,7 @@ def analyze_ci_failure(log_file_path: str):
         print(f"分析中にエラーが発生しました: {e}")
 ```
 
-### 8.4.2 マイグレーション問題診断
+### 8.5.2 マイグレーション問題診断
 
 #### データベースマイグレーション失敗の対処
 
@@ -3627,7 +3627,7 @@ if __name__ == "__main__":
     asyncio.run(emergency_migration_recovery(database_url, migration_version))
 ```
 
-### 8.4.3 バックアップ・復旧問題対応
+### 8.5.3 バックアップ・復旧問題対応
 
 #### バックアップ失敗の診断と対処
 
@@ -4028,7 +4028,7 @@ if __name__ == "__main__":
     backup_diagnosis_cli()
 ```
 
-### 8.4.4 監視・アラート問題対応
+### 8.5.4 監視・アラート問題対応
 
 #### 監視システム障害の診断
 
@@ -4569,7 +4569,7 @@ if __name__ == "__main__":
     asyncio.run(run_monitoring_diagnosis())
 ```
 
-### 8.4.5 運用自動化問題の予防策
+### 8.5.5 運用自動化問題の予防策
 
 #### プロアクティブ監視設定
 

--- a/docs/chapters/chapter09/index.md
+++ b/docs/chapters/chapter09/index.md
@@ -2961,5 +2961,5 @@ Chapter 10では、「**緊急救命室の医師**」レベルの問題解決力
 - **📚 目次**: [📖 学習ガイド]({{ '/introduction/' | relative_url }})
 - **⬅️ 前の章**: [Chapter 8: 運用監視と自動化]({{ '/chapters/chapter08/' | relative_url }})  
 - **➡️ 最終章**: [Chapter 10: トラブルシューティング]({{ '/chapters/chapter10/' | relative_url }})
-- **🏠 関連章**: [Chapter 3-5: アーキテクチャパターン]({{ '/chapters/chapter03/' | relative_url }}) | [選択ガイド]({{ '/pattern_selection_guide.html' | relative_url }})
-- **🔧 リソース**: [アーキテクチャ決定ツール]({{ site.baseurl }}/src/) | [移行チェックリスト]({{ '/operational_checklists.html' | relative_url }})
+- **🏠 関連章**: [Chapter 3-5: アーキテクチャパターン]({{ '/chapters/chapter03/' | relative_url }}) | [選択ガイド]({{ '/guides/pattern-selection/' | relative_url }})
+- **🔧 リソース**: [アーキテクチャ決定ツール]({{ site.repository }}/tree/main/src/chapters/chapter09/) | [移行チェックリスト]({{ '/appendices/appendix01/' | relative_url }}#operational-checklists)

--- a/docs/chapters/chapter10/index.md
+++ b/docs/chapters/chapter10/index.md
@@ -8,7 +8,7 @@ title: "Chapter 10: 統合実践プロジェクト 🏗️"
 ---
 **📚 目次に戻る**: [📖 学習ガイド]({{ '/introduction/' | relative_url }})  
 **⬅️ 前の章**: [Chapter 9: アーキテクチャ選択演習]({{ '/chapters/chapter09/' | relative_url }})  
-**➡️ 完了**: [🎓 学習修了・次のステップ]({{ site.baseurl }}/introduction/index.html#🎓-学習修了後の進路)  
+**➡️ 完了**: [🎓 学習修了・次のステップ]({{ '/introduction/' | relative_url }})  
 **🎯 学習フェーズ**: Part IV - 実践・応用編（統合実践）  
 **🎯 学習レベル**: 🌱 基礎 | 🚀 応用 | 💪 発展  
 **⏱️ 推定学習時間**: 8〜12時間  
@@ -1902,6 +1902,6 @@ Supabaseアーキテクチャパターンの学習が完了しました。実際
 **📍 最終ナビゲーション**
 - **📚 目次**: [📖 学習ガイド]({{ '/introduction/' | relative_url }})
 - **⬅️ 前の章**: [Chapter 9: アーキテクチャ選択演習]({{ '/chapters/chapter09/' | relative_url }})  
-- **🎓 修了後**: [学習継続ガイド]({{ site.baseurl }}/introduction/index.html#🎓-学習修了後の進路)
-- **🏠 復習**: [全章まとめ]({{ '/introduction/' | relative_url }}) | [パターン比較]({{ '/pattern_selection_guide.html' | relative_url }})
+- **🎓 修了後**: [学習継続ガイド]({{ '/introduction/' | relative_url }})
+- **🏠 復習**: [全章まとめ]({{ '/introduction/' | relative_url }}) | [パターン比較]({{ '/guides/pattern-selection/' | relative_url }})
 - **🔧 リソース**: [コミュニティ](https://supabase.com/community) | [公式ドキュメント](https://supabase.com/docs)

--- a/docs/guides/code-verification/index.md
+++ b/docs/guides/code-verification/index.md
@@ -1,0 +1,42 @@
+---
+layout: book
+order: 20
+title: "コード検証ガイド ✅"
+---
+# コード検証ガイド ✅
+
+---
+**📚 目次に戻る**: [📖 学習ガイド]({{ '/introduction/' | relative_url }})  
+**🎯 用途**: サンプルコード/手順が動くことを確認し、差分の破綻を早期に検出する  
+**📝 対象**: 開発者・レビュー担当  
+**⏱️ 利用方法**: 章末の「動作検証」リンクから参照し、必要なチェックのみ実行  
+---
+
+## 最小チェック（推奨）
+
+### 1) 原稿（src/）の静的チェック
+
+```bash
+npm test
+```
+
+補足:
+- `npm test` は `npm run lint` と `npm run check-links` を実行します。
+- 前提: Node.js 20+
+
+### 2) GitHub Pages（docs/）のビルド確認
+
+```bash
+bundle exec jekyll build --source docs
+```
+
+補足:
+- 前提: Ruby/Bundler（`Gemfile` 参照）
+- `docs/_config.yml` を使用してビルドします。
+
+## 参照（GitHub）
+
+- サンプルコード: {{ site.repository }}/tree/main/src/examples/
+- 統合チェックリスト: {{ site.repository }}/blob/main/INTEGRATION_CHECKLIST.md
+- 変更履歴: {{ site.repository }}/blob/main/CHANGELOG.md
+

--- a/docs/guides/glossary/index.md
+++ b/docs/guides/glossary/index.md
@@ -91,7 +91,7 @@ title: "技術用語索引・用語集 📚"
 - **定義**: 継続的インテグレーション・継続的デプロイメント
 - **Supabaseでの実装**: GitHub Actions + Supabase CLI
 - **実用例**: コード変更の自動テスト・自動デプロイ
-- **参照章**: [Chapter 5-3: 本番運用]({{ '/chapter05-3.html' | relative_url }})
+- **参照章**: [Chapter 5-3: 本番運用]({{ '/chapters/chapter05-3/' | relative_url }})
 
 ### D
 
@@ -125,7 +125,7 @@ title: "技術用語索引・用語集 📚"
 - **定義**: Python製の高性能Webフレームワーク
 - **Supabaseでの組み合わせ**: 独立APIサーバーパターン
 - **実用例**: 複雑なビジネスロジック・エンタープライズAPI
-- **参照章**: [Chapter 5: 独立APIサーバー]({{ '/chapter05-1.html' | relative_url }})
+- **参照章**: [Chapter 5: 独立APIサーバー]({{ '/chapters/chapter05-1/' | relative_url }})
 
 #### **Flet**
 `#framework` `#python` `#ui`
@@ -159,7 +159,7 @@ title: "技術用語索引・用語集 📚"
 - **定義**: 1つのシステムで複数の組織・顧客を安全に分離する設計
 - **Supabaseでの実装**: RLS + 組織ID分離
 - **実用例**: SaaS製品・複数企業の管理システム
-- **参照章**: [Chapter 5-2: マルチテナンシー]({{ '/chapter05-2.html' | relative_url }})
+- **参照章**: [Chapter 5-2: マルチテナンシー]({{ '/chapters/chapter05-2/' | relative_url }})
 
 ### P
 
@@ -191,7 +191,7 @@ title: "技術用語索引・用語集 📚"
 - **定義**: 高速インメモリデータストア・キャッシュ
 - **Supabaseでの組み合わせ**: 独立APIサーバーでのキャッシュ層
 - **実用例**: セッション保存・API レスポンスキャッシュ
-- **参照章**: [Chapter 5-2: Redis活用]({{ '/chapter05-2.html' | relative_url }})
+- **参照章**: [Chapter 5-2: Redis活用]({{ '/chapters/chapter05-2/' | relative_url }})
 
 #### **RLS（Row Level Security）**
 `#security` `#database`
@@ -214,7 +214,7 @@ title: "技術用語索引・用語集 📚"
 - **定義**: PythonのORM（オブジェクト関係マッピング）ライブラリ
 - **Supabaseでの組み合わせ**: FastAPI + PostgreSQL連携
 - **実用例**: Pythonコードでのデータベース操作
-- **参照章**: [Chapter 5: SQLAlchemy活用]({{ '/chapter05-1.html' | relative_url }})
+- **参照章**: [Chapter 5: SQLAlchemy活用]({{ '/chapters/chapter05-1/' | relative_url }})
 
 ### W
 
@@ -283,5 +283,5 @@ title: "技術用語索引・用語集 📚"
 **📍 ナビゲーション**
 - **📚 目次**: [📖 学習ガイド]({{ '/introduction/' | relative_url }})
 - **🏠 各章**: [Chapter 1-10]({{ '/introduction/' | relative_url }}) での学習時に参照
-- **🔧 関連リソース**: [付録]({{ '/appendix.html' | relative_url }}) | [トラブルシューティング]({{ '/troubleshooting_guide.html' | relative_url }})
+- **🔧 関連リソース**: [付録]({{ '/appendix.html' | relative_url }}) | [トラブルシューティング]({{ '/guides/troubleshooting/' | relative_url }})
 - **🌐 公式**: [Supabase公式ドキュメント](https://supabase.com/docs)

--- a/docs/guides/glossary/index.md
+++ b/docs/guides/glossary/index.md
@@ -283,5 +283,5 @@ title: "技術用語索引・用語集 📚"
 **📍 ナビゲーション**
 - **📚 目次**: [📖 学習ガイド]({{ '/introduction/' | relative_url }})
 - **🏠 各章**: [Chapter 1-10]({{ '/introduction/' | relative_url }}) での学習時に参照
-- **🔧 関連リソース**: [付録]({{ '/appendix.html' | relative_url }}) | [トラブルシューティング]({{ '/guides/troubleshooting/' | relative_url }})
+- **🔧 関連リソース**: [付録]({{ '/appendices/appendix-a/' | relative_url }}) | [トラブルシューティング]({{ '/guides/troubleshooting/' | relative_url }})
 - **🌐 公式**: [Supabase公式ドキュメント](https://supabase.com/docs)

--- a/docs/introduction/index.md
+++ b/docs/introduction/index.md
@@ -118,17 +118,17 @@ Supabaseマスターの核心部分
 
 **成果物**: サーバーレス薬剤管理システム
 
-#### [🏦 Chapter 5: パターン3 - 独立APIサーバー]({{ '/chapter05-1.html' | relative_url }})
+#### [🏦 Chapter 5: パターン3 - 独立APIサーバー]({{ '/chapters/chapter05-1/' | relative_url }})
 **比喩**: 鉄筋コンクリート（堅牢・高性能・企業向け）  
 **技術**: FastAPI + SQLAlchemy + Supabase  
 **サンプル**: 病院総合管理システム
 
 | セクション | ファイル | 内容 | 学習時間 | レベル |
 |:----------|:--------|:-----|:---------|:-------|
-| 5.1 基本設計 | [chapter05-1.md]({{ '/chapter05-1.html' | relative_url }}) | FastAPI基本構成・DB設計 | 3〜4時間 | 🌱🚀 |
-| 5.2 高度実装 | [chapter05-2.md]({{ '/chapter05-2.html' | relative_url }}) | マルチテナント・高度機能 | 4〜6時間 | 🚀💪 |
-| 5.3 運用・拡張 | [chapter05-3.md]({{ '/chapter05-3.html' | relative_url }}) | スケーリング・運用最適化 | 3〜4時間 | 💪 |
-| 5.4 AI/RAG | [chapter05-4.md]({{ '/chapter05-4.html' | relative_url }}) | RAG・埋め込み・監査ログ | 5〜7時間 | 💪 |
+| 5.1 基本設計 | [chapter05-1.md]({{ '/chapters/chapter05-1/' | relative_url }}) | FastAPI基本構成・DB設計 | 3〜4時間 | 🌱🚀 |
+| 5.2 高度実装 | [chapter05-2.md]({{ '/chapters/chapter05-2/' | relative_url }}) | マルチテナント・高度機能 | 4〜6時間 | 🚀💪 |
+| 5.3 運用・拡張 | [chapter05-3.md]({{ '/chapters/chapter05-3/' | relative_url }}) | スケーリング・運用最適化 | 3〜4時間 | 💪 |
+| 5.4 AI/RAG | [chapter05-4.md]({{ '/chapters/chapter05-4/' | relative_url }}) | RAG・埋め込み・監査ログ | 5〜7時間 | 💪 |
 
 **成果物**: エンタープライズ級病院管理システム
 
@@ -291,16 +291,16 @@ src/
 ## 📚 関連ドキュメント・リソース
 
 ### 📋 **実践ガイド集**
-- [🔧 トラブルシューティングガイド]({{ '/troubleshooting_guide.html' | relative_url }}) - 開発時の問題解決
-- [⚠️ エラーハンドリングガイド]({{ '/error_handling_guide.html' | relative_url }}) - 高度なエラー処理
-- [🎯 パターン選択ガイド]({{ '/pattern_selection_guide.html' | relative_url }}) - AI支援選択システム
-- [🔄 移行戦略ガイド]({{ '/migration_strategy.html' | relative_url }}) - パターン間移行戦略
-- [✅ 運用チェックリスト]({{ '/operational_checklists.html' | relative_url }}) - 本番運用対応
+- [🔧 トラブルシューティングガイド]({{ '/guides/troubleshooting/' | relative_url }}) - 開発時の問題解決
+- [⚠️ エラーハンドリングガイド]({{ '/guides/error-handling/' | relative_url }}) - 高度なエラー処理
+- [🎯 パターン選択ガイド]({{ '/guides/pattern-selection/' | relative_url }}) - AI支援選択システム
+- [🔄 移行戦略ガイド]({{ '/chapters/chapter09/' | relative_url }}) - パターン間移行戦略
+- [✅ 運用チェックリスト]({{ '/appendices/appendix01/' | relative_url }}#operational-checklists) - 本番運用対応
 
 ### 🔗 **統合ドキュメント**
-- [📖 バージョン履歴]({{ '/VERSION.html' | relative_url }}) - 改訂計画・変更履歴
-- [📋 技術書統合版]({{ '/supabase_textbook.html' | relative_url }}) - 全章統合版
-- [📊 コード検証ガイド]({{ '/code_verification.html' | relative_url }}) - 品質保証・検証手順
+- [📖 バージョン履歴]({{ site.repository }}/blob/main/CHANGELOG.md) - 改訂計画・変更履歴
+- [📄 EPUB/PDFガイド]({{ site.repository }}/blob/main/EPUB-PDF-GUIDE.md) - オフライン版の作成手順
+- [📊 コード検証ガイド]({{ '/guides/code-verification/' | relative_url }}) - 品質保証・検証手順
 
 ### 🌍 **外部リソース**
 - [Supabase公式ドキュメント](https://supabase.com/docs)


### PR DESCRIPTION
## 対応内容
- 旧URL（*.html や /src/ 等）でリンク切れになっていた内部リンクを、現行の公開パス（/chapters/・/guides/・/appendices/）へ更新しました。
- /src/ は GitHub Pages で除外されているため、参照先を GitHub リポジトリ（tree/blob）やガイドページへ付け替えました。
- 運用チェックリスト/環境構築の参照先として、付録に安定アンカー（#operational-checklists, #appendix-env-setup-scripts）を追加しました。
- Chapter 8 の節番号重複（8.4.1 の重複）を修正しました。
- コード検証ガイド（/guides/code-verification/）を追加し、「動作検証」リンクの参照先を統一しました。

Closes #126
