### PR TITLE
docs: add figure index and expose guides in sidebar

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -1,6 +1,21 @@
 introduction:
 - title: はじめに
   path: /introduction/
+guides:
+- title: 図版索引
+  path: /guides/figure-index/
+- title: 設計パターン選定ガイド
+  path: /guides/pattern-selection/
+- title: エラーハンドリングガイド
+  path: /guides/error-handling/
+- title: トラブルシューティングガイド
+  path: /guides/troubleshooting/
+- title: コード検証ガイド
+  path: /guides/code-verification/
+- title: 用語集
+  path: /guides/glossary/
+- title: Terminology Guide - 用語統一ガイド
+  path: /guides/terminology/
 chapters:
 - title: 第1章：Supabaseアーキテクチャ理解
   path: /chapters/chapter01/

--- a/docs/_includes/sidebar-nav.html
+++ b/docs/_includes/sidebar-nav.html
@@ -55,6 +55,21 @@
             </div>
             {% endif %}
 
+            {% if navigation.guides %}
+            <div class="toc-section">
+                <h4 class="toc-section-title">ガイド</h4>
+                <ul class="toc-list">
+                    {% for item in navigation.guides %}
+                    <li class="toc-item">
+                        <a href="{{ item.path | relative_url }}" class="toc-link {% if page.url == item.path or page.url contains item.path %}active{% endif %}" {% if page.url == item.path or page.url contains item.path %}aria-current="page"{% endif %}>
+                            {{ item.title }}
+                        </a>
+                    </li>
+                    {% endfor %}
+                </ul>
+            </div>
+            {% endif %}
+
             {% if navigation.additional %}
             <div class="toc-section">
                 <h4 class="toc-section-title">追加</h4>
@@ -135,4 +150,3 @@
         </div>
     </div>
 </div>
-

--- a/docs/guides/figure-index/index.md
+++ b/docs/guides/figure-index/index.md
@@ -1,0 +1,36 @@
+---
+layout: book
+order: 13
+title: "図版索引"
+---
+# 図版索引
+
+## このページの使い方
+
+本書で使っている主要な概念図を、章ごとに一覧できます。  
+設計判断を振り返るときや、章の関連図を素早く確認したいときに参照してください。
+
+## 図版一覧
+
+| 図版 | 主な用途 | 関連章 | ファイル |
+|---|---|---|---|
+| Supabase 全体像 | 3 層構成の全体把握 | 第1章 | `docs/assets/images/diagrams/supabase-architecture.svg` |
+| 認証フローと RLS | 認証と行レベル権限の関係確認 | 第2章 | `docs/assets/images/diagrams/auth-flow-rls.svg` |
+| RLS セキュリティ | 行レベル権限の防御モデル確認 | 第2章 / 第7章 | `docs/assets/images/diagrams/rls-security.svg` |
+| クライアント・Edge・API 比較 | パターン選定の比較確認 | 第3章〜第5章 | `docs/assets/images/diagrams/architecture-comparison.svg` |
+| マルチテナンシーモデル | SaaS 向け分離設計の確認 | 第5-2章 | `docs/assets/images/diagrams/multi-tenancy-model.svg` |
+| キャッシュ戦略 | パフォーマンス最適化の整理 | 第5-3章 / 第6章 | `docs/assets/images/diagrams/caching-strategy.svg` |
+| Realtime アーキテクチャ | リアルタイム更新の流れ確認 | 第1章 / 第5-4章 | `docs/assets/images/diagrams/realtime-architecture.svg` |
+
+## 参照のポイント
+
+- 図版は本文の補助として使い、実装手順は各章本文を優先して確認してください。
+- 章末や付録から図版を確認したい場合は、このページから該当章へ戻ると整理しやすくなります。
+- 変更が入った場合は、図版そのものよりも「何を比較し、何を判断する図か」を優先して読み直してください。
+
+## 関連ガイド
+
+- [設計パターン選定ガイド]({{ '/guides/pattern-selection/' | relative_url }})
+- [エラーハンドリングガイド]({{ '/guides/error-handling/' | relative_url }})
+- [トラブルシューティングガイド]({{ '/guides/troubleshooting/' | relative_url }})
+- [コード検証ガイド]({{ '/guides/code-verification/' | relative_url }})

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,7 @@ permalink: /
 
 ## ガイド
 
+- [図版索引]({{ site.baseurl }}/guides/figure-index/)
 - [設計パターン選定ガイド]({{ site.baseurl }}/guides/pattern-selection/)
 - [エラーハンドリングガイド]({{ site.baseurl }}/guides/error-handling/)
 - [トラブルシューティングガイド]({{ site.baseurl }}/guides/troubleshooting/)

--- a/docs/introduction/index.md
+++ b/docs/introduction/index.md
@@ -297,6 +297,7 @@ src/examples/
 ## 関連ドキュメント・リソース
 
 ### **実践ガイド集**
+- [図版索引]({{ '/guides/figure-index/' | relative_url }}) - 主要図版の参照
 - [トラブルシューティングガイド]({{ '/guides/troubleshooting/' | relative_url }}) - 開発時の問題解決
 - [[WARN] エラーハンドリングガイド]({{ '/guides/error-handling/' | relative_url }}) - 高度なエラー処理
 - [パターン選択ガイド]({{ '/guides/pattern-selection/' | relative_url }}) - AI支援選択システム

--- a/src/guides/figure-index/index.md
+++ b/src/guides/figure-index/index.md
@@ -1,8 +1,3 @@
----
-layout: book
-order: 13
-title: "図版索引"
----
 # 図版索引
 
 ## このページの使い方
@@ -30,7 +25,7 @@ title: "図版索引"
 
 ## 関連ガイド
 
-- [設計パターン選定ガイド]({{ '/guides/pattern-selection/' | relative_url }})
-- [エラーハンドリングガイド]({{ '/guides/error-handling/' | relative_url }})
-- [トラブルシューティングガイド]({{ '/guides/troubleshooting/' | relative_url }})
-- [コード検証ガイド]({{ '/guides/code-verification/' | relative_url }})
+- [設計パターン選定ガイド](../pattern-selection/)
+- [エラーハンドリングガイド](../error-handling/)
+- [トラブルシューティングガイド](../troubleshooting/)
+- [コード検証ガイド](../code-verification/)

--- a/src/guides/figure-index/index.md
+++ b/src/guides/figure-index/index.md
@@ -1,0 +1,36 @@
+---
+layout: book
+order: 13
+title: "図版索引"
+---
+# 図版索引
+
+## このページの使い方
+
+本書で使っている主要な概念図を、章ごとに一覧できます。  
+設計判断を振り返るときや、章の関連図を素早く確認したいときに参照してください。
+
+## 図版一覧
+
+| 図版 | 主な用途 | 関連章 | ファイル |
+|---|---|---|---|
+| Supabase 全体像 | 3 層構成の全体把握 | 第1章 | `docs/assets/images/diagrams/supabase-architecture.svg` |
+| 認証フローと RLS | 認証と行レベル権限の関係確認 | 第2章 | `docs/assets/images/diagrams/auth-flow-rls.svg` |
+| RLS セキュリティ | 行レベル権限の防御モデル確認 | 第2章 / 第7章 | `docs/assets/images/diagrams/rls-security.svg` |
+| クライアント・Edge・API 比較 | パターン選定の比較確認 | 第3章〜第5章 | `docs/assets/images/diagrams/architecture-comparison.svg` |
+| マルチテナンシーモデル | SaaS 向け分離設計の確認 | 第5-2章 | `docs/assets/images/diagrams/multi-tenancy-model.svg` |
+| キャッシュ戦略 | パフォーマンス最適化の整理 | 第5-3章 / 第6章 | `docs/assets/images/diagrams/caching-strategy.svg` |
+| Realtime アーキテクチャ | リアルタイム更新の流れ確認 | 第1章 / 第5-4章 | `docs/assets/images/diagrams/realtime-architecture.svg` |
+
+## 参照のポイント
+
+- 図版は本文の補助として使い、実装手順は各章本文を優先して確認してください。
+- 章末や付録から図版を確認したい場合は、このページから該当章へ戻ると整理しやすくなります。
+- 変更が入った場合は、図版そのものよりも「何を比較し、何を判断する図か」を優先して読み直してください。
+
+## 関連ガイド
+
+- [設計パターン選定ガイド]({{ '/guides/pattern-selection/' | relative_url }})
+- [エラーハンドリングガイド]({{ '/guides/error-handling/' | relative_url }})
+- [トラブルシューティングガイド]({{ '/guides/troubleshooting/' | relative_url }})
+- [コード検証ガイド]({{ '/guides/code-verification/' | relative_url }})


### PR DESCRIPTION
## 概要
- 図版索引ページを追加
- トップページと導入ページから図版索引へ導線を追加
- 既存 guides をサイドバーから辿れるように追加

## 変更点
- `docs/guides/figure-index/index.md` を追加
- `src/guides/figure-index/index.md` を追加
- `docs/_data/navigation.yml` に guides セクションを追加
- `docs/_includes/sidebar-nav.html` に guides セクション表示を追加
- `docs/index.md` と `docs/introduction/index.md` に図版索引への導線を追加

## 検証
- `bundle exec jekyll build --source docs --destination _site`
- ビルド後 HTML で `/guides/figure-index/` と sidebar の guides セクションを確認

Closes #136