### PR TITLE
[codex] Use PR list label on supabase top page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -80,7 +80,7 @@ permalink: /
 
 - 公開ページ: [GitHub Pages](https://itdojp.github.io/supabase-architecture-patterns-book/)
 - リポジトリ: [GitHub](https://github.com/itdojp/supabase-architecture-patterns-book)
-- 更新確認先: [コミット履歴](https://github.com/itdojp/supabase-architecture-patterns-book/commits/main/)、[Pull Requests](https://github.com/itdojp/supabase-architecture-patterns-book/pulls)
+- 更新確認先: [コミット履歴](https://github.com/itdojp/supabase-architecture-patterns-book/commits/main/)、[PR 一覧](https://github.com/itdojp/supabase-architecture-patterns-book/pulls)
 - 図版索引、設計パターン選定、トラブルシューティング、用語の再参照は上記ガイド節を起点にしてください。
 
 ## 著者について


### PR DESCRIPTION
## What changed
- update reader-facing change-tracking wording to `PR 一覧`

## Why
- align public guidance with the current wording used across this book series

## Validation
- `git diff --check`
- `bundle exec jekyll build --source docs --destination _site && node /home/devuser/work/CodeX/booksB/repos/book-formatter/scripts/check-links.js docs && node /home/devuser/work/CodeX/booksB/repos/book-formatter/scripts/check-markdown-structure.js docs --fail-on error`
