### PR TITLE
[codex] Clarify Supabase README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## オンライン版（推奨）
 
-- https://itdojp.github.io/supabase-architecture-patterns-book/
+- [Supabaseアーキテクチャパターン実践技術書](https://itdojp.github.io/supabase-architecture-patterns-book/)
 
 ## この本について
 


### PR DESCRIPTION
## Summary
- convert the public README URL to a Markdown link

## Testing
- npx --yes markdownlint-cli README.md
- git diff --check