### PR TITLE
[codex] Add metadata navigation consistency gate

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -48,6 +48,9 @@ jobs:
             echo "dir=." >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Validate metadata and navigation consistency
+        run: python3 scripts/check_metadata_consistency.py
+
       - name: Unicode check (fail on warnings)
         run: node book-formatter/scripts/check-unicode.js "${{ steps.scan.outputs.dir }}" --allowlist .book-formatter/unicode-allowlist.json --fail-on warn
 
@@ -121,7 +124,7 @@ jobs:
               return []
             data = yaml.safe_load(nav.read_text(encoding="utf-8")) or {}
             paths = []
-            for key in ["introduction", "chapters", "additional", "resources", "appendices", "afterword"]:
+            for key in ["introduction", "guides", "chapters", "additional", "resources", "appendices", "afterword"]:
               for item in (data.get(key) or []):
                 if isinstance(item, dict) and isinstance(item.get("items"), list):
                   for sub in (item.get("items") or []):
@@ -140,7 +143,7 @@ jobs:
 
           def discover_paths():
             paths = []
-            for seg in ["introduction", "chapters", "additional", "resources", "appendices", "afterword"]:
+            for seg in ["introduction", "guides", "chapters", "additional", "resources", "appendices", "afterword"]:
               d = scan_dir / seg
               if d.is_dir():
                 for child in sorted(d.iterdir()):

--- a/.github/workflows/nav-link-check.yml
+++ b/.github/workflows/nav-link-check.yml
@@ -52,14 +52,14 @@ jobs:
                   return []
               data = yaml.safe_load(y.read_text(encoding='utf-8')) or {}
               paths = []
-              for key in ['introduction','chapters','additional','resources','appendices','afterword']:
+              for key in ['introduction','guides','chapters','additional','resources','appendices','afterword']:
                   for item in (data.get(key) or []):
                       p = item.get('path') or ''
                       if p: paths.append(p)
               return paths
           def discover():
               paths=[]
-              for seg in ['introduction','chapters','appendices','afterword']:
+              for seg in ['introduction','guides','chapters','appendices','afterword']:
                   d = Path('docs')/seg
                   if d.is_dir():
                       for child in sorted(d.iterdir()):

--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ Supabase を題材に、UI クライアント / API サーバー / BaaS（Supaba
 
 - `LICENSE.md`（CC BY-NC-SA 4.0（商用は別契約） / シリーズ統一ライセンス準拠）
 
+## 品質ゲート（開発者向け）
+
+ローカルで最小確認を行う場合は、次を実行します。
+
+- `npm run check:metadata`
+- `npm test`
+- `bundle exec jekyll build --source docs --config docs/_config.yml --destination _site`
+
+`check:metadata` は `book-config.json`、`package.json`、`docs/_config.yml`、`docs/index.md`、`docs/_data/navigation.yml`、公開ページ、必須アセットの整合性を検証します。
+
 ## 執筆・ビルド（開発者向け）
 
 - クイックスタート: `QUICK-START.md`

--- a/_config.yml
+++ b/_config.yml
@@ -2,11 +2,14 @@
 title: "Supabaseアーキテクチャパターン実践技術書"
 description: "スケーラブルな3層構成の設計と実装 - 初心者から上級者まで段階的に学べる、Supabase完全マスターガイド"
 author: 
-  name: "株式会社アイティードゥ"
+  name: "ITDO Inc.（株式会社アイティードゥ）"
   github: itdojp
   email: knowledge@itdo.jp
 baseurl: "/supabase-architecture-patterns-book"
 url: "https://itdojp.github.io"
+version: "1.0.0"
+license: "CC-BY-NC-SA-4.0"
+homepage: "https://itdojp.github.io/supabase-architecture-patterns-book/"
 
 # Repository settings for links
 repository:

--- a/book-config.json
+++ b/book-config.json
@@ -12,11 +12,158 @@
     "branch": "main"
   },
   "structure": {
+    "introduction": [
+      {
+        "id": "introduction",
+        "title": "はじめに",
+        "description": "本書の目的、読み方、安全に使うための注意を整理する",
+        "path": "/introduction/"
+      }
+    ],
+    "guides": [
+      {
+        "id": "figure-index",
+        "title": "図版索引",
+        "description": "図版と設計要素の対応を一覧する",
+        "path": "/guides/figure-index/"
+      },
+      {
+        "id": "pattern-selection",
+        "title": "設計パターン選定ガイド",
+        "description": "要件に応じた Supabase アーキテクチャパターン選定を支援する",
+        "path": "/guides/pattern-selection/"
+      },
+      {
+        "id": "error-handling",
+        "title": "エラーハンドリングガイド",
+        "description": "Supabase 構成のエラー処理と復旧観点を整理する",
+        "path": "/guides/error-handling/"
+      },
+      {
+        "id": "troubleshooting",
+        "title": "トラブルシューティングガイド",
+        "description": "設計・実装・運用で発生しやすい問題の切り分けを支援する",
+        "path": "/guides/troubleshooting/"
+      },
+      {
+        "id": "code-verification",
+        "title": "コード検証ガイド",
+        "description": "サンプルコードと設定例の検証観点を整理する",
+        "path": "/guides/code-verification/"
+      },
+      {
+        "id": "glossary",
+        "title": "用語集",
+        "description": "本書で使う Supabase / アーキテクチャ用語を定義する",
+        "path": "/guides/glossary/"
+      },
+      {
+        "id": "terminology",
+        "title": "Terminology Guide - 用語統一ガイド",
+        "description": "日本語・英語表記と略語の揺れを抑える",
+        "path": "/guides/terminology/"
+      }
+    ],
     "chapters": [
       {
         "id": "chapter01",
-        "title": "第1章：基礎概念",
-        "description": "基本的な概念と原理"
+        "title": "第1章：Supabaseアーキテクチャ理解",
+        "description": "Supabase 全体像と基本構成を理解する",
+        "path": "/chapters/chapter01/"
+      },
+      {
+        "id": "chapter02",
+        "title": "第2章：認証・認可設計",
+        "description": "認証・認可と RLS 設計を整理する",
+        "path": "/chapters/chapter02/"
+      },
+      {
+        "id": "chapter03",
+        "title": "第3章：パターン1 - クライアントサイド実装",
+        "description": "クライアント直結パターンの設計判断を学ぶ",
+        "path": "/chapters/chapter03/"
+      },
+      {
+        "id": "chapter04",
+        "title": "第4章：パターン2 - Edge Functions活用",
+        "description": "Edge Functions を用いたサーバーレス構成を学ぶ",
+        "path": "/chapters/chapter04/"
+      },
+      {
+        "id": "chapter05-1",
+        "title": "第5-1章：パターン3 - 独立APIサーバー",
+        "description": "独立 API サーバー導入時の責務分割を学ぶ",
+        "path": "/chapters/chapter05-1/"
+      },
+      {
+        "id": "chapter05-2",
+        "title": "第5-2章：マルチテナンシーと複雑ビジネスロジック",
+        "description": "SaaS 向けのマルチテナント設計を整理する",
+        "path": "/chapters/chapter05-2/"
+      },
+      {
+        "id": "chapter05-3",
+        "title": "第5-3章：拡張性設計とパフォーマンス最適化",
+        "description": "スケーリングと性能最適化の設計観点を学ぶ",
+        "path": "/chapters/chapter05-3/"
+      },
+      {
+        "id": "chapter05-4",
+        "title": "第5-4章：RAG/ベクトル検索アーキテクチャ",
+        "description": "RAG とベクトル検索を Supabase 構成へ組み込む",
+        "path": "/chapters/chapter05-4/"
+      },
+      {
+        "id": "chapter06",
+        "title": "第6章：パフォーマンス最適化",
+        "description": "ボトルネック特定と最適化の実務手順を学ぶ",
+        "path": "/chapters/chapter06/"
+      },
+      {
+        "id": "chapter07",
+        "title": "第7章：セキュリティ強化",
+        "description": "Supabase システムのセキュリティ設計と運用を整理する",
+        "path": "/chapters/chapter07/"
+      },
+      {
+        "id": "chapter08",
+        "title": "第8章：運用監視と自動化",
+        "description": "監視、バックアップ、自動化の運用設計を学ぶ",
+        "path": "/chapters/chapter08/"
+      },
+      {
+        "id": "chapter09",
+        "title": "第9章：アーキテクチャ選択演習",
+        "description": "要件に応じたパターン選定を演習する",
+        "path": "/chapters/chapter09/"
+      },
+      {
+        "id": "chapter10",
+        "title": "第10章：統合実践プロジェクト",
+        "description": "統合プロジェクトで設計判断を実践する",
+        "path": "/chapters/chapter10/"
+      }
+    ],
+    "appendices": [
+      {
+        "id": "appendix-a",
+        "title": "付録A: 技術リソース集",
+        "description": "Supabase と関連技術の参照リソースを整理する",
+        "path": "/appendices/appendix-a/"
+      },
+      {
+        "id": "appendix01",
+        "title": "付録B: 参考資料",
+        "description": "環境構築、チェックリスト、トラブルシューティングを収録する",
+        "path": "/appendices/appendix01/"
+      }
+    ],
+    "afterword": [
+      {
+        "id": "afterword",
+        "title": "あとがき",
+        "description": "本書のまとめと継続的な学習の方向性を示す",
+        "path": "/afterword/"
       }
     ]
   },
@@ -43,5 +190,6 @@
   "shared": {
     "version": "3.2.2",
     "lastSync": "2026-02-04T23:01:39.914Z"
-  }
+  },
+  "homepage": "https://itdojp.github.io/supabase-architecture-patterns-book/"
 }

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,7 +1,10 @@
 # Jekyll Configuration for Supabase Architecture Patterns Book
 title: "Supabaseアーキテクチャパターン実践技術書"
 description: "スケーラブルな3層構成の設計と実装 - 初心者から上級者まで段階的に学べる、Supabase完全マスターガイド"
-author: "株式会社アイティードゥ"
+author: "ITDO Inc.（株式会社アイティードゥ）"
+version: "1.0.0"
+license: "CC-BY-NC-SA-4.0"
+homepage: "https://itdojp.github.io/supabase-architecture-patterns-book/"
 lang: "ja"
 url: "https://itdojp.github.io"
 baseurl: "/supabase-architecture-patterns-book"

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -48,3 +48,6 @@ appendices:
   path: /appendices/appendix-a/
 - title: '付録B: 参考資料'
   path: /appendices/appendix01/
+afterword:
+- title: あとがき
+  path: /afterword/

--- a/package.json
+++ b/package.json
@@ -14,12 +14,13 @@
     "preview": "npm run build && npx http-server _site -p 8080 --silent",
     "deploy": "gh-pages -d _site",
     "clean": "rm -rf _site .jekyll-cache",
-    "test": "npm run lint && npm run check-links",
+    "test": "npm run check:metadata && npm run lint && npm run check-links",
     "lint": "markdownlint 'src/**/*.md' --ignore node_modules",
     "lint:light": "markdownlint 'src/**/*.md' --ignore node_modules",
     "check-links": "markdown-link-check src/**/*.md",
     "check-conflicts": "echo 'No Jekyll conflicts to check'",
-    "help": "echo 'Available commands:\n  npm start - Start development server\n  npm run build - Build the book\n  npm run preview - Local preview\n  npm run deploy - Deploy to GitHub Pages'"
+    "help": "echo 'Available commands:\n  npm start - Start development server\n  npm run build - Build the book\n  npm run preview - Local preview\n  npm run deploy - Deploy to GitHub Pages'",
+    "check:metadata": "python3 scripts/check_metadata_consistency.py"
   },
   "dependencies": {},
   "devDependencies": {
@@ -32,7 +33,9 @@
     "book",
     "documentation",
     "japanese",
-    "supabase","architecture","patterns"
+    "supabase",
+    "architecture",
+    "patterns"
   ],
   "repository": {
     "type": "git",
@@ -41,5 +44,5 @@
   "bugs": {
     "url": "https://github.com/itdojp/supabase-architecture-patterns-book/issues"
   },
-  "homepage": "https://github.com/itdojp/supabase-architecture-patterns-book#readme"
+  "homepage": "https://itdojp.github.io/supabase-architecture-patterns-book/"
 }

--- a/scripts/check_metadata_consistency.py
+++ b/scripts/check_metadata_consistency.py
@@ -1,0 +1,372 @@
+from __future__ import annotations
+
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote
+
+REPOSITORY = "itdojp/supabase-architecture-patterns-book"
+REPO_URL = f"https://github.com/{REPOSITORY}"
+REPO_GIT_URL = f"{REPO_URL}.git"
+PAGES_URL = "https://itdojp.github.io/supabase-architecture-patterns-book/"
+TITLE = "Supabaseアーキテクチャパターン実践技術書"
+DESCRIPTION = "スケーラブルな3層構成の設計と実装 - 初心者から上級者まで段階的に学べる、Supabase完全マスターガイド"
+AUTHOR = "ITDO Inc.（株式会社アイティードゥ）"
+VERSION = "1.0.0"
+LICENSE = "CC-BY-NC-SA-4.0"
+SECTION_KEYS = ["introduction", "guides", "chapters", "appendices", "afterword"]
+REQUIRED_ASSETS = [
+    "assets/css/main.css",
+    "assets/css/syntax-highlighting.css",
+    "assets/js/theme.js",
+    "assets/js/search.js",
+    "assets/js/code-copy-lightweight.js",
+]
+
+
+@dataclass(frozen=True)
+class Entry:
+    section: str
+    title: str
+    path: str
+
+
+@dataclass(frozen=True)
+class Page:
+    path: Path
+    public_path: str
+    title: str | None
+
+
+FRONT_MATTER_RE = re.compile(r"^---\r?\n(.*?)\r?\n---\r?\n", re.DOTALL)
+SCALAR_RE = re.compile(r"^(?P<key>[A-Za-z0-9_-]+):\s*(?P<value>.*?)\s*$")
+SECTION_RE = re.compile(r"^(?P<section>[A-Za-z0-9_-]+):\s*$")
+TITLE_RE = re.compile(r"^\s*-\s*title:\s*(?P<value>.+?)\s*$")
+PATH_RE = re.compile(r"^\s*path:\s*(?P<value>.+?)\s*$")
+
+
+class CheckError(ValueError):
+    pass
+
+
+def unquote_scalar(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+        return value[1:-1]
+    return value
+
+
+def parse_scalar_block(text: str) -> dict[str, str]:
+    data: dict[str, str] = {}
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or line[:1].isspace():
+            continue
+        match = SCALAR_RE.match(line)
+        if match:
+            data[match.group("key")] = str(unquote_scalar(match.group("value")))
+    return data
+
+
+def parse_front_matter(path: Path) -> dict[str, str]:
+    match = FRONT_MATTER_RE.match(path.read_text(encoding="utf-8"))
+    if not match:
+        return {}
+    return parse_scalar_block(match.group(1))
+
+
+def normalize_public_path(value: Any, *, source: str) -> str:
+    if not isinstance(value, str):
+        raise CheckError(f"{source}: path must be a string")
+    path = value.strip()
+    if not path:
+        raise CheckError(f"{source}: path must not be empty")
+    if path.startswith(("http://", "https://", "mailto:")):
+        raise CheckError(f"{source}: external paths are not allowed: {path!r}")
+    if "{{" in path or "}}" in path:
+        raise CheckError(f"{source}: Liquid expressions are not allowed in canonical paths")
+    if "#" in path or "?" in path:
+        raise CheckError(f"{source}: path must not include query or fragment: {path!r}")
+    if "\\" in path:
+        raise CheckError(f"{source}: path must use forward slashes: {path!r}")
+    if not path.startswith("/"):
+        path = "/" + path
+    decoded = unquote(path)
+    parts = [part for part in decoded.split("/") if part]
+    if any(part in (".", "..") for part in parts):
+        raise CheckError(f"{source}: path traversal is not allowed: {path!r}")
+    if "%2f" in path.lower() or "%5c" in path.lower():
+        raise CheckError(f"{source}: encoded path separators are not allowed: {path!r}")
+    lower = path.lower()
+    if path != "/" and not lower.endswith((".md", ".html", ".htm", ".pdf", ".txt", "/")):
+        path += "/"
+    return path
+
+
+def parse_navigation(path: Path) -> dict[str, list[Entry]]:
+    data: dict[str, list[Entry]] = {key: [] for key in SECTION_KEYS}
+    current_section: str | None = None
+    pending_title: str | None = None
+    for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        section_match = SECTION_RE.match(stripped)
+        if section_match and not line[:1].isspace():
+            current_section = section_match.group("section")
+            if current_section not in data:
+                data[current_section] = []
+            pending_title = None
+            continue
+        if current_section is None:
+            continue
+        title_match = TITLE_RE.match(line)
+        if title_match:
+            pending_title = str(unquote_scalar(title_match.group("value")))
+            continue
+        path_match = PATH_RE.match(line)
+        if path_match:
+            if pending_title is None:
+                raise CheckError(f"{path}:{lineno}: path without preceding title")
+            data.setdefault(current_section, []).append(
+                Entry(
+                    section=current_section,
+                    title=pending_title,
+                    path=normalize_public_path(unquote_scalar(path_match.group("value")), source=f"{path}:{lineno}"),
+                )
+            )
+            pending_title = None
+    if pending_title is not None:
+        raise CheckError(f"{path}: title without path at end of file")
+    return data
+
+
+def require_str(mapping: dict[str, Any], key: str, *, source: str) -> str:
+    value = mapping.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise CheckError(f"{source}.{key} must be a non-empty string")
+    return value.strip()
+
+
+def collect_book_entries(book: dict[str, Any]) -> dict[str, list[Entry]]:
+    structure = book.get("structure")
+    if not isinstance(structure, dict):
+        raise CheckError("book-config.json: structure must be an object")
+    result: dict[str, list[Entry]] = {key: [] for key in SECTION_KEYS}
+    for section in SECTION_KEYS:
+        raw_items = structure.get(section)
+        if not isinstance(raw_items, list):
+            raise CheckError(f"book-config.json: structure.{section} must be a list")
+        for i, item in enumerate(raw_items):
+            source = f"book-config.json: structure.{section}[{i}]"
+            if not isinstance(item, dict):
+                raise CheckError(f"{source} must be an object")
+            for key in ("id", "title", "description", "path"):
+                require_str(item, key, source=source)
+            result[section].append(
+                Entry(
+                    section=section,
+                    title=require_str(item, "title", source=source),
+                    path=normalize_public_path(item.get("path"), source=f"{source}.path"),
+                )
+            )
+    return result
+
+
+def page_path_for(file_path: Path) -> str | None:
+    if file_path.parts[0] != "docs":
+        return None
+    if any(part.startswith("_") for part in file_path.parts[1:]):
+        return None
+    if "assets" in file_path.parts:
+        return None
+    if file_path.name != "index.md":
+        return None
+    if file_path == Path("docs/index.md"):
+        return "/"
+    rel_parent = file_path.parent.relative_to("docs")
+    return "/" + str(rel_parent).replace("\\", "/").strip("/") + "/"
+
+
+def collect_pages() -> list[Page]:
+    pages: list[Page] = []
+    for file_path in sorted(Path("docs").glob("**/index.md")):
+        public_path = page_path_for(file_path)
+        if public_path is None:
+            continue
+        fm = parse_front_matter(file_path)
+        permalink = fm.get("permalink")
+        if permalink:
+            public_path = normalize_public_path(permalink, source=f"{file_path}:permalink")
+        pages.append(Page(path=file_path, public_path=public_path, title=fm.get("title")))
+    return pages
+
+
+def duplicate_values(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    duplicates: list[str] = []
+    for value in values:
+        if value in seen and value not in duplicates:
+            duplicates.append(value)
+        seen.add(value)
+    return duplicates
+
+
+def compare_sections(book_entries: dict[str, list[Entry]], nav_entries: dict[str, list[Entry]]) -> list[str]:
+    errors: list[str] = []
+    for section in SECTION_KEYS:
+        book = book_entries.get(section, [])
+        nav = nav_entries.get(section, [])
+        if len(book) != len(nav):
+            errors.append(f"{section}: count mismatch (book-config={len(book)}, navigation={len(nav)})")
+        for i, (book_item, nav_item) in enumerate(zip(book, nav)):
+            if book_item.title != nav_item.title:
+                errors.append(f"{section}: title mismatch at index {i} (book-config={book_item.title!r}, navigation={nav_item.title!r})")
+            if book_item.path != nav_item.path:
+                errors.append(f"{section}: path mismatch at index {i} (book-config={book_item.path!r}, navigation={nav_item.path!r})")
+        if len(book) > len(nav):
+            errors.append(f"{section}: extra in book-config: {book[len(nav):]!r}")
+        elif len(nav) > len(book):
+            errors.append(f"{section}: extra in navigation: {nav[len(book):]!r}")
+    return errors
+
+
+def validate_metadata(book: dict[str, Any], package: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    expected_book = {
+        "title": TITLE,
+        "description": DESCRIPTION,
+        "author": AUTHOR,
+        "version": VERSION,
+        "language": "ja",
+        "license": LICENSE,
+        "homepage": PAGES_URL,
+    }
+    for key, expected in expected_book.items():
+        actual = book.get(key)
+        if actual != expected:
+            errors.append(f"book-config.json: {key} must be {expected!r} (actual={actual!r})")
+    repository = book.get("repository")
+    if not isinstance(repository, dict):
+        errors.append("book-config.json: repository must be an object")
+    else:
+        expected_repo = {"owner": "itdojp", "name": "supabase-architecture-patterns-book", "url": REPO_GIT_URL, "branch": "main"}
+        for key, expected in expected_repo.items():
+            actual = repository.get(key)
+            if actual != expected:
+                errors.append(f"book-config.json: repository.{key} must be {expected!r} (actual={actual!r})")
+
+    expected_package = {
+        "name": "supabase-architecture-patterns-book",
+        "version": VERSION,
+        "description": "Supabaseアーキテクチャパターン - 実践的な設計手法",
+        "author": AUTHOR,
+        "license": LICENSE,
+        "homepage": PAGES_URL,
+    }
+    for key, expected in expected_package.items():
+        actual = package.get(key)
+        if actual != expected:
+            errors.append(f"package.json: {key} must be {expected!r} (actual={actual!r})")
+    pkg_repo = package.get("repository")
+    if not isinstance(pkg_repo, dict) or pkg_repo.get("url") != f"git+{REPO_GIT_URL}":
+        errors.append("package.json: repository.url must match canonical git+ GitHub URL")
+    pkg_bugs = package.get("bugs")
+    if not isinstance(pkg_bugs, dict) or pkg_bugs.get("url") != f"{REPO_URL}/issues":
+        errors.append("package.json: bugs.url must match canonical GitHub issues URL")
+
+    docs_cfg = parse_scalar_block(Path("docs/_config.yml").read_text(encoding="utf-8"))
+    expected_docs = {
+        "title": TITLE,
+        "description": DESCRIPTION,
+        "author": AUTHOR,
+        "version": VERSION,
+        "license": LICENSE,
+        "homepage": PAGES_URL,
+        "lang": "ja",
+        "url": "https://itdojp.github.io",
+        "baseurl": "/supabase-architecture-patterns-book",
+        "repository": REPO_URL,
+    }
+    for key, expected in expected_docs.items():
+        actual = docs_cfg.get(key)
+        if actual != expected:
+            errors.append(f"docs/_config.yml: {key} must be {expected!r} (actual={actual!r})")
+
+    index_fm = parse_front_matter(Path("docs/index.md"))
+    expected_index = {
+        "title": TITLE,
+        "description": DESCRIPTION,
+        "author": AUTHOR,
+        "version": VERSION,
+        "permalink": "/",
+    }
+    for key, expected in expected_index.items():
+        actual = index_fm.get(key)
+        if actual != expected:
+            errors.append(f"docs/index.md: front matter {key} must be {expected!r} (actual={actual!r})")
+    return errors
+
+
+def validate_pages_and_assets(entries: list[Entry]) -> list[str]:
+    errors: list[str] = []
+    pages = collect_pages()
+    page_paths = [page.public_path for page in pages]
+    configured_paths = [entry.path for entry in entries]
+    for duplicate in duplicate_values(page_paths):
+        errors.append(f"duplicate public page path: {duplicate}")
+    for duplicate in duplicate_values(configured_paths):
+        errors.append(f"duplicate configured path: {duplicate}")
+    page_set = set(page_paths)
+    configured_set = set(configured_paths) | {"/"}
+    for entry in entries:
+        if entry.path not in page_set:
+            errors.append(f"configured path has no docs page: {entry.section}:{entry.title} -> {entry.path}")
+    for page in pages:
+        if page.public_path not in configured_set:
+            errors.append(f"docs page is not listed in book-config/navigation: {page.path} -> {page.public_path}")
+    for asset in REQUIRED_ASSETS:
+        path = Path("docs") / asset
+        if not path.is_file() or path.stat().st_size == 0:
+            errors.append(f"required public asset is missing or empty: docs/{asset}")
+    return errors
+
+
+def main() -> int:
+    try:
+        book = json.loads(Path("book-config.json").read_text(encoding="utf-8"))
+        package = json.loads(Path("package.json").read_text(encoding="utf-8"))
+        if not isinstance(book, dict):
+            raise CheckError("book-config.json must be a JSON object")
+        if not isinstance(package, dict):
+            raise CheckError("package.json must be a JSON object")
+        book_entries = collect_book_entries(book)
+        nav_entries = parse_navigation(Path("docs/_data/navigation.yml"))
+    except (CheckError, json.JSONDecodeError) as e:
+        sys.stderr.write(f"{e}\n")
+        return 1
+
+    errors: list[str] = []
+    errors.extend(validate_metadata(book, package))
+    errors.extend(compare_sections(book_entries, nav_entries))
+    all_entries = [entry for section in SECTION_KEYS for entry in book_entries.get(section, [])]
+    errors.extend(validate_pages_and_assets(all_entries))
+
+    if errors:
+        sys.stderr.write("metadata consistency check failed:\n")
+        for error in errors:
+            sys.stderr.write(f"- {error}\n")
+        return 1
+
+    counts = ", ".join(f"{section}={len(book_entries.get(section, []))}" for section in SECTION_KEYS)
+    print(f"OK: metadata, navigation, configured pages, and assets match ({counts})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add a stdlib `scripts/check_metadata_consistency.py` gate covering canonical metadata, navigation sections, configured public pages, required public assets, and unsafe path patterns.
- Expand `book-config.json` from a single stale chapter entry to the currently published introduction, guides, chapters, appendices, and afterword routes.
- Add the afterword to navigation, include `guides` in nav/Book QA smoke checks, and align package/Jekyll homepage/version/license/author metadata.
- Wire `check:metadata` into `npm test`, Book QA, and README local verification guidance.

## Why
The published site already contains guides and an afterword, but the existing machine-readable metadata and smoke checks did not cover those routes. This PR makes the publication contract explicit so future navigation, metadata, or asset drift fails before merge.

## Validation
- Baseline: existing `npm test` and Bundler-backed `docs` Jekyll build passed before changes; `npm ci` reported existing dev-dependency audit findings, while `npm audit --omit=dev --omit=optional` was 0 vulnerabilities.
- `python3 -m py_compile scripts/check_metadata_consistency.py`
- `python3 scripts/check_metadata_consistency.py`
- `npm test`
- `npm audit --omit=dev --omit=optional`
- `BUNDLE_PATH=/home/devuser/work/CodeX/booksB/.codex-local/tmp/supabase-bundle bundle exec jekyll build --source docs --config docs/_config.yml --destination /home/devuser/work/CodeX/booksB/.codex-local/tmp/supabase-site-after` (existing Liquid warnings in chapter05-3/chapter08 code examples only)
- book-formatter pinned at `itdojp/book-formatter@da2a49e7d2dcd9e1fa885e910c458130fe8d73a4`: unicode, textlint, internal links, layout risk, markdown structure
- Built-site smoke for `/`, `/introduction/`, `/guides/code-verification/`, `/chapters/chapter08/`, `/appendices/appendix-a/`, `/afterword/`, and required assets
- Negative fixtures: package homepage drift and navigation path drift failed as expected; CRLF front matter fixture passed
- `git diff --check`