### PR TITLE
fix: 公開versionとJekyll build設定を同期する

### DIFF
--- a/book-config.json
+++ b/book-config.json
@@ -179,11 +179,11 @@
     "modules": {
       "quickStart": false,
       "readingGuide": true,
-      "checklistPack": false,
-      "troubleshootingFlow": false,
-      "conceptMap": true,
+      "checklistPack": true,
+      "troubleshootingFlow": true,
+      "conceptMap": false,
       "figureIndex": true,
-      "legalNotice": true,
+      "legalNotice": false,
       "glossary": true
     }
   },

--- a/docs/introduction/index.md
+++ b/docs/introduction/index.md
@@ -7,11 +7,11 @@ title: "はじめに"
 
 **初心者から上級者まで段階的に学べる、Supabase 完全マスターガイド**
 
-![Version: 1.0](https://img.shields.io/badge/Version-1.0-brightgreen.svg)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-brightgreen.svg)
 ![Status: Active Development](https://img.shields.io/badge/Status-Active%20Development-green.svg)
 
 - **著者**: 株式会社アイティードゥ
-- **版**: 1.0版
+- **版**: 1.0.0版
 - **最終更新**: 2026年5月23日
 
 ---

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "node": ">=20.18.1"
   },
   "scripts": {
-    "start": "jekyll serve --livereload",
-    "build": "bundle exec jekyll build",
-    "build:gh-pages": "bundle exec jekyll build",
+    "start": "bundle exec jekyll serve --source docs --config docs/_config.yml --destination _site --livereload",
+    "build": "bundle exec jekyll build --source docs --config docs/_config.yml --destination _site",
+    "build:gh-pages": "bundle exec jekyll build --source docs --config docs/_config.yml --destination _site",
     "preview": "npm run build && npx http-server _site -p 8080 --silent",
     "deploy": "gh-pages -d _site",
     "clean": "rm -rf _site .jekyll-cache",

--- a/scripts/check_metadata_consistency.py
+++ b/scripts/check_metadata_consistency.py
@@ -267,7 +267,11 @@ def validate_public_version() -> list[str]:
     for relative_path in ("src/introduction/index.md", "docs/introduction/index.md"):
         path = Path(relative_path)
         text = path.read_text(encoding="utf-8")
-        if f"Version: {VERSION}" not in text:
+        badge_pattern = (
+            rf"^!\[Version: {re.escape(VERSION)}\]"
+            rf"\(https://img\.shields\.io/badge/Version-{re.escape(VERSION)}-brightgreen\.svg\)$"
+        )
+        if not re.search(badge_pattern, text, re.MULTILINE):
             errors.append(f"{relative_path}: version badge must display {VERSION!r}")
         edition_pattern = rf"^\s*(?:-\s*)?\*\*版\*\*:\s*{re.escape(VERSION)}版\s*$"
         if not re.search(edition_pattern, text, re.MULTILINE):

--- a/scripts/check_metadata_consistency.py
+++ b/scripts/check_metadata_consistency.py
@@ -25,6 +25,22 @@ REQUIRED_ASSETS = [
     "assets/js/search.js",
     "assets/js/code-copy-lightweight.js",
 ]
+EXPECTED_UX_MODULES = {
+    "quickStart": False,
+    "readingGuide": True,
+    "checklistPack": True,
+    "troubleshootingFlow": True,
+    "conceptMap": False,
+    "figureIndex": True,
+    "legalNotice": False,
+    "glossary": True,
+}
+REQUIRED_READER_ROUTES = {
+    "figure index": "/guides/figure-index/",
+    "glossary": "/guides/glossary/",
+    "troubleshooting": "/guides/troubleshooting/",
+    "checklist evidence": "/appendices/appendix01/#operational-checklists",
+}
 
 
 @dataclass(frozen=True)
@@ -246,6 +262,56 @@ def compare_sections(book_entries: dict[str, list[Entry]], nav_entries: dict[str
     return errors
 
 
+def validate_public_version() -> list[str]:
+    errors: list[str] = []
+    for relative_path in ("src/introduction/index.md", "docs/introduction/index.md"):
+        path = Path(relative_path)
+        text = path.read_text(encoding="utf-8")
+        if f"Version: {VERSION}" not in text:
+            errors.append(f"{relative_path}: version badge must display {VERSION!r}")
+        if f"版**: {VERSION}版" not in text:
+            errors.append(f"{relative_path}: edition must display {VERSION!r}")
+    return errors
+
+
+def validate_ux_and_reader_routes(book: dict[str, Any], entries: list[Entry]) -> list[str]:
+    errors: list[str] = []
+    ux = book.get("ux")
+    modules = ux.get("modules") if isinstance(ux, dict) else None
+    if not isinstance(modules, dict):
+        return ["book-config.json: ux.modules must be an object"]
+    for key, expected in EXPECTED_UX_MODULES.items():
+        actual = modules.get(key)
+        if actual != expected:
+            errors.append(f"book-config.json: ux.modules.{key} must be {expected!r} (actual={actual!r})")
+
+    configured_paths = {entry.path for entry in entries}
+    for label, route in REQUIRED_READER_ROUTES.items():
+        route_path = route.split("#", 1)[0]
+        if route_path not in configured_paths:
+            errors.append(f"reader route missing ({label}): {route}")
+    checklist = Path("docs/appendices/appendix01/index.md").read_text(encoding="utf-8")
+    if "{#operational-checklists}" not in checklist:
+        errors.append("reader route missing (checklist evidence): #operational-checklists anchor")
+    return errors
+
+
+def validate_build_scripts(package: dict[str, Any]) -> list[str]:
+    errors: list[str] = []
+    scripts = package.get("scripts")
+    if not isinstance(scripts, dict):
+        return ["package.json: scripts must be an object"]
+    expected = {
+        "start": "bundle exec jekyll serve --source docs --config docs/_config.yml --destination _site --livereload",
+        "build": "bundle exec jekyll build --source docs --config docs/_config.yml --destination _site",
+        "build:gh-pages": "bundle exec jekyll build --source docs --config docs/_config.yml --destination _site",
+    }
+    for name, command in expected.items():
+        if scripts.get(name) != command:
+            errors.append(f"package.json: scripts.{name} must be {command!r} (actual={scripts.get(name)!r})")
+    return errors
+
+
 def validate_metadata(book: dict[str, Any], package: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     expected_book = {
@@ -383,6 +449,9 @@ def main() -> int:
     errors.extend(validate_metadata(book, package))
     errors.extend(compare_sections(book_entries, nav_entries))
     all_entries = [entry for section in SECTION_KEYS for entry in book_entries.get(section, [])]
+    errors.extend(validate_public_version())
+    errors.extend(validate_ux_and_reader_routes(book, all_entries))
+    errors.extend(validate_build_scripts(package))
     errors.extend(validate_pages_and_assets(all_entries))
 
     if errors:

--- a/scripts/check_metadata_consistency.py
+++ b/scripts/check_metadata_consistency.py
@@ -269,7 +269,8 @@ def validate_public_version() -> list[str]:
         text = path.read_text(encoding="utf-8")
         if f"Version: {VERSION}" not in text:
             errors.append(f"{relative_path}: version badge must display {VERSION!r}")
-        if f"版**: {VERSION}版" not in text:
+        edition_pattern = rf"^\s*(?:-\s*)?\*\*版\*\*:\s*{re.escape(VERSION)}版\s*$"
+        if not re.search(edition_pattern, text, re.MULTILINE):
             errors.append(f"{relative_path}: edition must display {VERSION!r}")
     return errors
 

--- a/src/introduction/index.md
+++ b/src/introduction/index.md
@@ -3,11 +3,11 @@
 **初心者から上級者まで段階的に学べる、Supabase完全マスターガイド**
 
 ![License: CC BY-NC-SA 4.0](https://img.shields.io/badge/License-CC%20BY--NC--SA%204.0-lightgrey.svg)
-![Version: 1.0](https://img.shields.io/badge/Version-1.0-brightgreen.svg)
+![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-brightgreen.svg)
 ![Status: Active Development](https://img.shields.io/badge/Status-Active%20Development-green.svg)
 
 **著者**: 株式会社アイティードゥ  
-**版**: 1.0版  
+**版**: 1.0.0版
 **最終更新**: 2026年5月23日
 
 ---


### PR DESCRIPTION
## 概要

公開版のversion・UX metadataと、ローカルJekyll buildのsource/config/destinationをreader-facingな実体へ同期します。

## 変更

- introの版表示をcanonical `1.0.0`へ同期（src/docs）
- 実在するチェックリスト・トラブルシューティングをtrueへ修正
- 未実装concept mapと一般ライセンス節をfalseへ修正
- npmのJekyllコマンドを`docs` source / `docs/_config.yml` / root `_site`へ限定
- version、UX、reader routes、build commandのmetadata gateを追加

## 検証

- `npm ci --omit=optional`
- `npm audit`: 0 vulnerabilities
- `npm test`
- version / build command negative fixtures
- `npm run build` / `npm run build:gh-pages`: Jekyll warning 0
- built-site smoke: top / introduction / figure index / glossary / troubleshooting
- 管理文書・examplesがbuilt-siteへ混入しないことを確認
- `git diff --check`

## 分離した残課題

- 専用concept map: itdojp/it-engineer-knowledge-architecture#220

Closes #147
Related: itdojp/it-engineer-knowledge-architecture#219
