### PR TITLE
ci: pin Book QA formatter to audited cff9fcf

### DIFF
--- a/.github/workflows/book-qa.yml
+++ b/.github/workflows/book-qa.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: itdojp/book-formatter
-          ref: 69eb5c12f5a750b65614bc9bbbc3d7abd5aa6f6c
+          ref: cff9fcf8bae31140f07b358d314fc64173cb7013
           path: book-formatter
 
       - name: Setup Node.js


### PR DESCRIPTION
## 概要（必須）

- Book QA の `itdojp/book-formatter` immutable ref を監査済み `cff9fcf8bae31140f07b358d314fc64173cb7013` に更新します。
- one-line pin-only の変更です。

## 影響範囲（必須）

- 対象章/ページ: なし（CI formatter pin のみ）
- 影響: `.github/workflows/book-qa.yml` の `ref` 1 行。本文、consumer dependency/lockfile、build 契約、Pages 設定は未変更。

## QA（必須）

- [x] exact formatter checkout (`cff9fcf…`) の `npm ci` / `npm audit --audit-level=high`: 0 vulnerabilities
- [x] `BOOK_FORMATTER_DIR` 指定: Unicode 0、Textlint 0、links 107、layout errors/warnings 0、Markdown structure errors/warnings 0
- [x] repository QA（security audit 以外）: metadata、auth/users、authz、Chapter 4 Deno 13 tests、lint、links 277/277: PASS
- [x] Pages-compatible Jekyll build / built-link smoke / workflow-equivalent Pages smoke: 26 paths / 5 assets PASS
- [x] `git diff --check`: PASS、PR diff は workflow ref 1 行のみ
- [x] Book QA（GitHub exact head）: success

## consumer audit の分離と解消

- consumer high 7件は Issue #162 / PR #163で分離して処理し、reviewed head `953851b...` を通常squash merge `a072046...` としてmainへ反映済みです。
- main Book QA 32702714952 / Docs 32702714946 / Pages 32702714862 はsuccess、public root HTTP 200を確認しました。
- 更新mainをこのpin branchへrebaseではなく通常mergeし、exact head `a6503d2803478d5244a9d4895a626e7be6a94ff7` を作成しました。
- mainに対する最終PR差分はformatter ref 1行のみを維持しています。
- exact-head Book QA 32702991459 / Docs 32702991307 はsuccess。consumer / target formatter audit high/criticalは `0 / 0` です。

## Review Completion Gate（必須）

- [x] GitHub Copilot review の本文・inline comment・suggestion を全件確認した
- [x] 対応が必要な指摘は修正・返信・resolve 済み
- [x] 未対応の指摘: 0
- [x] マージ前に未解決 review thread が 0 件であることを確認した

## Pages確認（原則必須）

- 確認URL: https://itdojp.github.io/supabase-architecture-patterns-book/
- [x] preflight public root HTTP 200
- [x] local Pages-compatible build/smoke: PASS
- [ ] マージ後の Pages 確認は別途必要

## 補足

- Source Issue: #161
- Ref: itdojp/it-engineer-knowledge-architecture#286
- 通常merge gateのみ使用。rebase、force push、main直接push、admin bypass、settings変更は行いません。


## Final review evidence

- Copilot review: actionable inline / suggestion `0`
- Codex exact-head review: no major issues
- Review completeness: unresolved / mismatch / missing = `0 / 0 / 0`
